### PR TITLE
[#54] Update operator policies according to recent FA2 changes

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -344,16 +344,13 @@ Parameter (in Michelson)
 
 Types
 ```
-self_transfer_policy =
-  | Self_transfer_permitted
-  | Self_transfer_denied
-
 operator_transfer_policy =
-  | Operator_transfer_permitted
-  | Operator_transfer_denied
+  | No_transfer
+  | Owner_transfer
+  | Owner_or_operator_transfer
 
-owner_transfer_policty =
-  | Owner_no_op
+owner_hook_policy =
+  | Owner_no_hook
   | Optional_owner_hook
   | Required_owner_hook
 
@@ -363,10 +360,9 @@ custom_permission_policy =
   )
 
 permissions_descriptor_param
-  ( self_transfer_policy            :self
-  , operator_transfer_policy        :receiver
-  , owner_transfer_policty          :operator
-  , owner_transfer_policty          :sender
+  ( operator_transfer_policy        :operator
+  , owner_hook_policy               :receiver
+  , owner_hook_policy               :sender
   , option custom_permission_policy :custom
   )
 
@@ -377,35 +373,31 @@ Parameter (in Michelson)
 ```
 (contract %permissions_descriptor
   (pair
-    (or %self
-      (unit %self_transfer_permitted)
-      (unit %self_transfer_denied)
-    )
     (pair
       (or %operator
-        (unit %operator_transfer_permitted)
-        (unit %operator_transfer_denied)
+        (unit %owner_transfer)
+        (unit %no_transfer)
       )
+    (pair
+      (or %receiver
+        (unit %owner_no_op)
+        (or
+          (unit %optional_owner_hook)
+          (unit %required_owner_hook)
+      ))
       (pair
-        (or %receiver
+        (or %sender
           (unit %owner_no_op)
           (or
             (unit %optional_owner_hook)
             (unit %required_owner_hook)
         ))
+      (option %custom
         (pair
-          (or %sender
-            (unit %owner_no_op)
-            (or
-              (unit %optional_owner_hook)
-              (unit %required_owner_hook)
-          ))
-        (option %custom
-          (pair
-            (string %tag)
-            (option %config_api address)
-          )
+          (string %tag)
+          (option %config_api address)
         )
+      )
   ))))
 )
 ```

--- a/haskell/src/Lorentz/Contracts/Spec/FA2Interface.hs
+++ b/haskell/src/Lorentz/Contracts/Spec/FA2Interface.hs
@@ -14,14 +14,13 @@ module Lorentz.Contracts.Spec.FA2Interface
   , IsOperatorParam
   , IsOperatorResponse
   , OperatorParam
-  , OperatorTransferMode (..)
+  , OperatorTransferPolicy (..)
   , OwnerTransferMode (..)
   , Parameter (..)
   , FA2ParameterC
   , PermissionsDescriptor
   , PermissionsDescriptorMaybe
   , PermissionsDescriptorParam
-  , SelfTransferMode (..)
   , TokenId
   , TokenMetaDataParam
   , TokenMetadata
@@ -105,37 +104,22 @@ instance Buildable TokenMetadata where
     "token_id:" +| token_id |+ ", symbol:" +| symbol |+ ", name:" +|
     name |+ ", decimals:" +| decimals |+ "."
 
--- Permission descriptor param components and parameter
-data SelfTransferMode
-  = SelfTransferPermitted ("self_transfer_permitted" :! ())
-  | SelfTransferDenied ("self_transfer_denied" :! ())
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass (IsoValue, HasTypeAnn)
-
-instance Arbitrary SelfTransferMode where
-  arbitrary =
-    elements
-      [ SelfTransferPermitted (#self_transfer_permitted .! ())
-      , SelfTransferDenied (#self_transfer_denied .! ())
-      ]
-
-instance TypeHasDoc SelfTransferMode where
-  typeDocMdDescription = "Describes if token owner can make transfers themselves"
-
-data OperatorTransferMode
-  = OperatorTransferPermitted ("operator_transfer_permitted" :! ())
-  | OperatorTransferDenied ("operator_transfer_denied" :! ())
+data OperatorTransferPolicy
+  = OwnerTransfer ("owner_transfer" :! ())
+  | NoTransfer ("no_transfer" :! ())
+  | OwnerOrOperatorTransfer ("owner_or_operator_transfer" :! ())
   deriving stock (Eq, Generic, Show)
   deriving anyclass (IsoValue, HasTypeAnn)
 
-instance Arbitrary OperatorTransferMode where
+instance Arbitrary OperatorTransferPolicy where
   arbitrary =
     elements
-      [ OperatorTransferPermitted (#operator_transfer_permitted .! ())
-      , OperatorTransferDenied (#operator_transfer_denied .! ())
+      [ OwnerTransfer (#owner_transfer .! ())
+      , NoTransfer (#no_transfer .! ())
+      , OwnerOrOperatorTransfer (#owner_or_operator_transfer .! ())
       ]
 
-instance TypeHasDoc OperatorTransferMode where
+instance TypeHasDoc OperatorTransferPolicy where
   typeDocMdDescription = "Describes if operator can make transfer on behalf of token owner"
 
 data OwnerTransferMode
@@ -173,11 +157,10 @@ type family PdFld (f :: PdTag) t where
 -- tuple elements that is used for setting some specific parameter
 -- when passing them in tests.
 type PermissionsDescriptorPoly t =
-  ( "self" :! PdFld t SelfTransferMode
-  , "pdr" :! ( "operator" :! PdFld t OperatorTransferMode
+  ( "operator" :! PdFld t OperatorTransferPolicy
   , "pdr2" :! ( "receiver" :! PdFld t OwnerTransferMode
   , "pdr3" :!
-      ("sender" :! PdFld t OwnerTransferMode, "custom" :! PdFld t (Maybe CustomPermissionPolicy)))))
+      ("sender" :! PdFld t OwnerTransferMode, "custom" :! PdFld t (Maybe CustomPermissionPolicy))))
 
 type PermissionsDescriptor = PermissionsDescriptorPoly 'PdFull
 type PermissionsDescriptorMaybe = PermissionsDescriptorPoly 'PdMaybe

--- a/haskell/test/Lorentz/Contracts/Test/Management.hs
+++ b/haskell/test/Lorentz/Contracts/Test/Management.hs
@@ -32,7 +32,7 @@ managementSpec originate = do
         originationParams =
             addAccount (wallet1, (commonOperators, 0))
           $ defaultOriginationParams
-              { opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed
+              { opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer
               }
       withOriginated originate originationParams $ \stablecoinContract -> do
         lTransfer @param
@@ -95,7 +95,7 @@ managementSpec originate = do
             addAccount (wallet1, (commonOperators, 10))
           $ addAccount (wallet2, ([], 0))
           $ defaultOriginationParams
-              { opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed
+              { opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer
               , opPaused = True
               }
       withOriginated originate originationParams $ \stablecoinContract -> do
@@ -110,7 +110,7 @@ managementSpec originate = do
           $ addAccount (wallet2, (commonOperators, 0))
           $ addAccount (wallet3, (commonOperators, 0))
           $ defaultOriginationParams
-              { opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed
+              { opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer
               , opPaused = True
               }
 
@@ -229,7 +229,7 @@ managementSpec originate = do
 
         withSender masterMinter $ lCallEP stablecoinContract (Call @"Configure_minter") configureMinterParam2
 
-        validate . Left $ lExpectAnyMichelsonFailed stablecoinContract
+        validate . Left $  lExpectAnyMichelsonFailed stablecoinContract
 
     it "fails if sender does not have master minter permissions" $ integrationalTestExpectation $ do
       withOriginated originate defaultOriginationParams $ \stablecoinContract -> do
@@ -313,7 +313,7 @@ managementSpec originate = do
         originationParams =
             addMinter (wallet1, 30)
           $ defaultOriginationParams
-              { opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed }
+              { opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer }
       withOriginated originate originationParams $ \stablecoinContract -> do
         let
           mintings =
@@ -621,7 +621,7 @@ managementSpec originate = do
         let
           originationParams = addAccount (wallet1, (commonOperators, 10))
               $ defaultOriginationParams {
-                  opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed,
+                  opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer,
                   opSafelistContract = Just safelistContract
                 }
         withOriginated originate originationParams $ \stablecoinContract -> do
@@ -639,7 +639,7 @@ managementSpec originate = do
           originationParams = addAccount (wallet1, (commonOperators, 10))
               $ addMinter (wallet1, 30)
               $ defaultOriginationParams {
-                  opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed,
+                  opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer,
                   opSafelistContract = Just safelistContract
                 }
         withOriginated originate originationParams $ \stablecoinContract -> do
@@ -675,7 +675,7 @@ managementSpec originate = do
         let
           originationParams = addAccount (wallet1, (commonOperators, 10))
               $ defaultOriginationParams {
-                  opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed,
+                  opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer,
                   opSafelistContract = Just safelistContract
                 }
         withOriginated originate originationParams $ \stablecoinContract -> do
@@ -693,7 +693,7 @@ managementSpec originate = do
           originationParams = addAccount (wallet1, (commonOperators, 10))
               $ addMinter (wallet1, 30)
               $ defaultOriginationParams {
-                  opPermissionsDescriptor = permissionDescriptorOperatorTransferAllowed,
+                  opPermissionsDescriptor = permissionDescriptorOwnerOrOperatorTransfer,
                   opSafelistContract = Just safelistContract
                 }
         withOriginated originate originationParams $ \stablecoinContract -> do

--- a/ligo/stablecoin/actions.ligo
+++ b/ligo/stablecoin/actions.ligo
@@ -396,12 +396,10 @@ function permission_descriptor
   ( const parameter : permissions_descriptor_params
   ; const store     : storage
   ) : entrypoint is block
-  {
-    const self_permissions : self_transfer_policy = Layout.convert_to_right_comb((Self_transfer_permitted : self_transfer_policy_))
-  ; const operator_permissions : operator_transfer_policy = Layout.convert_to_right_comb((Operator_transfer_permitted : operator_transfer_policy_))
-  ; const owner_hook_policy : owner_transfer_policy = Layout.convert_to_right_comb((Optional_owner_hook : owner_transfer_policy_))
+  { const operator_permissions : operator_transfer_policy = Layout.convert_to_right_comb((Owner_or_operator_transfer : operator_transfer_policy_))
+  ; const owner_hook_policy : owner_hook_policy = Layout.convert_to_right_comb((Optional_owner_hook : owner_hook_policy_))
   ; const permissions : permissions_descriptor =
-      (self_permissions, (operator_permissions, (owner_hook_policy, (owner_hook_policy, (None : option (custom_permission_policy))))))
+      (operator_permissions, (owner_hook_policy, (owner_hook_policy, (None : option (custom_permission_policy)))))
 
 } with
   ( list [Tezos.transaction

--- a/ligo/stablecoin/spec.ligo
+++ b/ligo/stablecoin/spec.ligo
@@ -140,24 +140,19 @@ type is_operator_params is michelson_pair_right_comb(is_operator_params_)
 
 (* ------------------------------------------------------------- *)
 
-type self_transfer_policy_ is
-| Self_transfer_permitted
-| Self_transfer_denied
-
-type self_transfer_policy is michelson_or_right_comb(self_transfer_policy_)
-
 type operator_transfer_policy_ is
-| Operator_transfer_permitted
-| Operator_transfer_denied
+| No_transfer
+| Owner_transfer
+| Owner_or_operator_transfer
 
 type operator_transfer_policy is michelson_or_right_comb(operator_transfer_policy_)
 
-type owner_transfer_policy_ is
-| Owner_no_op
+type owner_hook_policy_ is
+| Owner_no_hook
 | Optional_owner_hook
 | Required_owner_hook
 
-type owner_transfer_policy is michelson_or_right_comb(owner_transfer_policy_)
+type owner_hook_policy is michelson_or_right_comb(owner_hook_policy_)
 
 type custom_permission_policy_ is record
   tag        : string
@@ -167,10 +162,9 @@ end
 type custom_permission_policy is michelson_pair_right_comb(custom_permission_policy_)
 
 type permissions_descriptor_ is record
-  self     : self_transfer_policy
-; operator : operator_transfer_policy
-; receiver : owner_transfer_policy
-; sender   : owner_transfer_policy
+  operator : operator_transfer_policy
+; receiver : owner_hook_policy
+; sender   : owner_hook_policy
 ; custom   : option (custom_permission_policy)
 end
 


### PR DESCRIPTION
## Description

In the latest [FA2](https://gitlab.com/tzip/tzip/-/blob/b916f32718234b7c4016f46e00327d66702511a2/proposals/tzip-12/tzip-12.md) version there is only `operator_transfer_policy` which combines former `self_transfer_policy` and `operator_transfer_policy`. Our code was not updated to account for that and so this MR resolves this problem.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #54 
partly #55 (renames `owner_no_op` to `owner_no_hook`)

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [X] If I added new functionality, I added tests covering it.
  - [X] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
