### PR TITLE
[TM-417] Allow nettests run fail once

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,9 @@ steps:
      - mkdir -p test/resources/
      - nix-build -A tezos-contract -o test/resources/stablecoin.tz
      - nix run -f. tezos-client -c ./scripts/ci/run-local-chain-nettest.sh result/bin/stablecoin-nettest
+   retry: &retry-nettest
+      automatic:
+        limit: 1
  - label: nettest-scheduled
    if: build.source == "schedule"
    env:
@@ -47,6 +50,7 @@ steps:
      # more tz, its address: tz1PmUUbZFoQndXvx8gEbS58NvacQhmCUg9Y
      MONEYBAG: "unencrypted:edsk35MZSeehREYkbvnuNJzgt2m3AhWnWHwqpeQdRS85aLygqrA61G"
    commands: *run-nettest
+   retry: *retry-nettest
  - label: check LIGO contract
    if: build.source != "schedule"
    command: nix build -L -f. tezos-contract

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,7 @@ steps:
      TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
      NETTEST_NODE_ADDR: "localhost"
      NETTEST_NODE_PORT: "8734"
-     MONEYBAG: "unencrypted:edsk47wWUSCHRDC1Hxtg7yxXzocwDjBJJRqTKnoP7htAifSpzwkg8K"
+     MONEYBAG: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
    commands: &run-nettest
      - nix build -L -f. nettest
      - mkdir -p test/resources/
@@ -47,8 +47,8 @@ steps:
      NETTEST_NODE_ADDR: "carthage.testnet.tezos.serokell.team"
      NETTEST_NODE_PORT: "8732"
      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
-     # more tz, its address: tz1PmUUbZFoQndXvx8gEbS58NvacQhmCUg9Y
-     MONEYBAG: "unencrypted:edsk35MZSeehREYkbvnuNJzgt2m3AhWnWHwqpeQdRS85aLygqrA61G"
+     # more tz, its address: tz1ij8gUYbMRUXa4xX3mNvKguhaWG9GGbURn
+     MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
    retry: *retry-nettest
  - label: check LIGO contract


### PR DESCRIPTION
## Description
Problem: Local-chain tests are a bit flaky and may fail due to network
problems that don't really indicate any bugs. Restarting them manually
and getting extra notifications about failed builds can be annoying.

Solution: Allow nettest retry one time in case of failure.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TM-417

Resolves #37 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
