### PR TITLE
[#78] Produce static stablecoin-client for linux on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,6 +75,14 @@ steps:
      # weeder needs .cabal file:
      - nix run -f.. pkgs.haskellPackages.hpack -c hpack
      - ./result
+ - label: packaging
+   if: *not_scheduled
+   commands:
+     - eval "$FETCH_CONTRACT"
+     - nix-build -A stablecoin-client -o stablecoin-static
+     - nix run -f . pkgs.upx -c upx stablecoin-static/bin/stablecoin-client -o stablecoin-client
+   artifact_paths:
+     - ./stablecoin-client
 
 notify:
   - email: "tezos-alerts@serokell.io"

--- a/default.nix
+++ b/default.nix
@@ -2,19 +2,24 @@
 # SPDX-License-Identifier: MIT
 
 { sources ? import ./nix/sources.nix
+, static ? true
 , haskell-nix ? import sources."haskell.nix" { }
 , pkgs ? import sources.nixpkgs haskell-nix.nixpkgsArgs
 , weeder-hacks ? import sources.haskell-nix-weeder { inherit pkgs; }
 , ligo ? (import "${sources.ligo}/nix" { }).ligo-bin
 }:
 let
+  haskell-nix =
+    if static
+    then pkgs.pkgsCross.musl64.haskell-nix
+    else pkgs.haskell-nix;
   local-packages = [{
       name = "stablecoin";
       subdirectory = ".";
   }];
   local-packages-names = map (p: p.name) local-packages;
-  project = pkgs.haskell-nix.stackProject {
-    src = pkgs.haskell-nix.haskellLib.cleanGit {
+  project = haskell-nix.stackProject {
+    src = haskell-nix.haskellLib.cleanGit {
       name = "stablecoin";
       src = ./haskell;
     };

--- a/haskell/src/Stablecoin/Client/Impl.hs
+++ b/haskell/src/Stablecoin/Client/Impl.hs
@@ -343,7 +343,6 @@ getStorage (arg #contract -> contract) = do
 
 data StablecoinClientError
   = SCEExpressionParseError Expression FromExpressionError
-  | forall k v. SCEBigMapNotFound Text (BigMapId k v)
 
 deriving stock instance Show StablecoinClientError
 
@@ -352,8 +351,6 @@ instance Buildable StablecoinClientError where
     "Failed to parse expression:\n" +|
     expr |+ "\n" <>
     "Parse error: " +| err |+ ""
-  build (SCEBigMapNotFound bigMapName bigMapId) =
-    "Big map '" +| bigMapName |+ "' with ID '" +| bigMapId |+ "' not found"
 
 instance Exception StablecoinClientError where
   displayException = pretty


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem: In #77, we added the `stablecoin-client` executable. Users
don't want to build it from sources, we need to make it more convenient
to obtain it. 

Solution: Configure CI to build an artifact with the static executable.


Example build with the `stablecoin-client` artifact: https://buildkite.com/serokell/stablecoin/builds/754#4cf20eff-41e8-4866-97c0-f0b9a07f1707

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #78

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
