### PR TITLE
[#82] Update ligo revision

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,13 +5,20 @@ SPDX-License-Identifier: MIT
 # Changelog for stablecoin
 
 ## 1.1.0
-* [#75](Incorporate safelist contract changes according to TZIP-15):
+* [#84](https://github.com/tqtezos/stablecoin/pull/84)
+  Update LIGO version.
+  As a consequence the size of the contract was substantially decreased.
+* [#79](https://github.com/tqtezos/stablecoin/pull/79)
+  Implement `stablecoin-client`.
+* [#75](https://github.com/tqtezos/stablecoin/pull/75)
+  Incorporate safelist contract changes according to TZIP-15:
   1. Safelist renamed to "Transferlist".
   2. Transferlist interaction updated to be able to use external transferlists.
 
 ## 1.0.0
 
-* [#73](Update the contract to a newer FA2 revision):
+* [#73](https://github.com/tqtezos/stablecoin/pull/73)
+  Update the contract to a newer FA2 revision:
   1. No `total_supply`.
   2. New way of exposing metadata.
   3. Slightly modified error messages.

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -4,7 +4,7 @@
 <<: !include "./hpack/module.yaml"
 
 name:                stablecoin
-version:             1.0.0
+version:             1.1.0
 
 extra-source-files:
 - README.md

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,4 @@
 {
-    "haskell.nix": {
-        "branch": "master",
-        "description": "Alternative Haskell Infrastructure for Nixpkgs",
-        "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "f4136211c933b444ab2e0f358abd223929970220",
-        "sha256": "1b9nxzkg29hwczr6pb6a7arxka8z0swzq7b2bqyxqzr4qvpcjlc1",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/f4136211c933b444ab2e0f358abd223929970220.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell-nix-weeder": {
         "branch": "master",
         "description": "haskell.nix + weeder",
@@ -23,10 +11,22 @@
         "url": "https://github.com/serokell/haskell-nix-weeder/archive/7f11f514b54474c3281b25ac2c09975c918e0492.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "haskell.nix": {
+        "branch": "master",
+        "description": "Alternative Haskell Infrastructure for Nixpkgs",
+        "homepage": "https://input-output-hk.github.io/haskell.nix",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "f4136211c933b444ab2e0f358abd223929970220",
+        "sha256": "1b9nxzkg29hwczr6pb6a7arxka8z0swzq7b2bqyxqzr4qvpcjlc1",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f4136211c933b444ab2e0f358abd223929970220.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "ligo": {
         "ref": "dev",
         "repo": "https://gitlab.com/ligolang/ligo",
-        "rev": "599944343d117de1fd929aa77134d5ef3ecbd479",
+        "rev": "3862c0444416a2e4aba7ad116eff675cacc324d3",
         "type": "git"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Description

Problem: we want to check how recent ligo changes affect
the size of generated Michelson code. Also we want to keep
up with ligo updates since ligo is actively developed.

Solution: update ligo version to the latest `dev` branch
using the following command:
> niv update ligo --attribute rev=3862c0444416a2e4aba7ad116eff675cacc324d3

HEAD of `dev` was chosen because it has
https://gitlab.com/ligolang/ligo/-/merge_requests/732 that was
just recently merged and that we are interested it.


## Related issue(s)

Resolves #82

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
