### PR TITLE
[OPS-1023] CI: update dependencies, pin hackage and stackage indexes independently

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,9 @@
 
 { sources ? import ./nix/sources.nix
 , static ? true
-, haskell-nix ? import sources."haskell.nix" { }
+, haskell-nix ? import sources."haskell.nix" {
+    sourceOverrides = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
+  }
 , pkgs ? import sources.nixpkgs haskell-nix.nixpkgsArgs
 , weeder-hacks ? import sources.haskell-nix-weeder { inherit pkgs; }
 , ligo ? (import "${sources.ligo}/nix" { }).ligo-bin

--- a/default.nix
+++ b/default.nix
@@ -46,10 +46,20 @@ let
     installPhase = "cp stablecoin.tz $out";
   };
   tezos-client = (import "${sources.tezos-packaging}/pkgs.nix" {}).ocamlPackages.tezos-client;
+
+  # nixpkgs has weeder 2, but we use weeder 1
+  weeder-legacy = pkgs.haskellPackages.callHackageDirect {
+    pkg = "weeder";
+    ver = "1.0.9";
+    sha256 = "0gfvhw7n8g2274k74g8gnv1y19alr1yig618capiyaix6i9wnmpa";
+  } {};
+
   weeder-script = weeder-hacks.weeder-script {
+    weeder = weeder-legacy;
     hs-pkgs = project;
     local-packages = local-packages;
   };
+
   morley =
     (pkgs.haskell-nix.hackage-package
       { name = "morley"; version = "1.4.0"; compiler-nix-name = "ghc883"; }

--- a/default.nix
+++ b/default.nix
@@ -56,7 +56,6 @@ let
     ).components.exes.morley;
 in
 {
-  all = project.stablecoin.components.all;
   lib = project.stablecoin.components.library;
   test = project.stablecoin.components.tests.stablecoin-test;
   nettest = project.stablecoin.components.tests.stablecoin-nettest;

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2020 tqtezos
 # SPDX-License-Identifier: MIT
 
+# To update hackage and stackage indexes used by CI run:
+# $ niv update hackage.nix; niv update stackage.nix
 resolver: lts-16.5
 
 packages:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "serokell",
         "repo": "haskell-nix-weeder",
-        "rev": "7f11f514b54474c3281b25ac2c09975c918e0492",
-        "sha256": "0nww0cx8sjn8gg5k6371f17kdbp72nmdz34hwa9sxwvrmxzagg2x",
+        "rev": "a959fce7499df473e13336959cba77fbc87f3b7f",
+        "sha256": "1pmlndvbhzxj1k5f87d9dxfa00zbvmkmvnbd1davzwg77bd639l0",
         "type": "tarball",
-        "url": "https://github.com/serokell/haskell-nix-weeder/archive/7f11f514b54474c3281b25ac2c09975c918e0492.tar.gz",
+        "url": "https://github.com/serokell/haskell-nix-weeder/archive/a959fce7499df473e13336959cba77fbc87f3b7f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -35,10 +35,10 @@
         "homepage": "",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "6951747f4f4e9e27580150eb91587af94e41640d",
-        "sha256": "03rl26632vrbpqfbdvrkbh8gfvn6na5dq8k16xib723gf1p1xd3l",
+        "rev": "ec2598d025b7670472175413748ce688a60712b9",
+        "sha256": "0b1acpgy9jbf57zxqk0zqza7yk2a70q8mrhd519rq8kmgc95dw1x",
         "type": "tarball",
-        "url": "https://github.com/serokell/nixpkgs/archive/6951747f4f4e9e27580150eb91587af94e41640d.tar.gz",
+        "url": "https://github.com/serokell/nixpkgs/archive/ec2598d025b7670472175413748ce688a60712b9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "hackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions for Hackage",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6be2e8a47504a4753dc8786bdc401ace902869cd",
+        "sha256": "1dj3ks79jnh2w2npy8q0yaxngcz0d5r8l8ihqgy7afjy7wpmn1gm",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/6be2e8a47504a4753dc8786bdc401ace902869cd.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "haskell-nix-weeder": {
         "branch": "master",
         "description": "haskell.nix + weeder",
@@ -39,6 +51,18 @@
         "sha256": "0b1acpgy9jbf57zxqk0zqza7yk2a70q8mrhd519rq8kmgc95dw1x",
         "type": "tarball",
         "url": "https://github.com/serokell/nixpkgs/archive/ec2598d025b7670472175413748ce688a60712b9.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "stackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions of Stackage snapshots",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "f50e24fa7a734f2291e8d940be33d917aa7456ad",
+        "sha256": "0rw35vllm81nnmvjqsl09qs00bw7gmj965p88rd250n80nv1g5c9",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/f50e24fa7a734f2291e8d940be33d917aa7456ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {


### PR DESCRIPTION
## Description

Makes sure that haskell.nix revision used in CI is the same as most of our other projects have, to reduce number of ghc builds
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

OPS-1023

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
