### PR TITLE
[#86] Prune zero balance accounts

### DIFF
--- a/haskell/test/SMT.hs
+++ b/haskell/test/SMT.hs
@@ -720,7 +720,9 @@ applyParameter cc@(ContractCall {..}) cs = case ccParameter of
   _ -> error "Unexpected call"
 
 applyDebit :: Address -> Natural ->  SimpleStorage -> SimpleStorage
-applyDebit from amount ss@SimpleStorage {..} =  ss { ssLedger = Map.update (\x -> Just $ x - amount) from ssLedger }
+applyDebit from amount ss@SimpleStorage {..} =  ss
+  { ssLedger =
+      Map.update (\x -> let n = x - amount in if n == 0 then Nothing else Just n) from ssLedger }
 
 applyCredit :: Address -> Natural -> SimpleStorage -> SimpleStorage
 applyCredit from amount ss@SimpleStorage {..} =

--- a/ligo/stablecoin/actions.ligo
+++ b/ligo/stablecoin/actions.ligo
@@ -140,12 +140,12 @@ function debit_from
   | None -> 0n // Interpret non existant account as zero balance as per FA2
   end
 
-; if parameter.amount > curr_balance
-      then failwith ("FA2_INSUFFICIENT_BALANCE")
-      else
-      { const updated_balance : nat = abs (curr_balance - parameter.amount)
-      ; updated_ledger := Big_map.update(parameter.from_, Some (updated_balance), updated_ledger)
-      }
+ ; const updated_balance: option(nat) = case is_nat(curr_balance - parameter.amount) of
+       Some (ub) -> if ub = 0n then (None : option(nat)) else Some(ub) // If balance is 0 set None to remove it from ledger
+     | None -> (failwith ("FA2_INSUFFICIENT_BALANCE") : option(nat))
+     end
+ ; updated_ledger := Big_map.update(parameter.from_, updated_balance, updated_ledger)
+
 } with store with record [ ledger = updated_ledger ]
 
 (*


### PR DESCRIPTION
## Description

Change contract that when an account ends up with a zero balance, it is removed from the ledger. Add tests for transfer and burn to check zero balance account is removed after the operations.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #86 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
