### PR TITLE
[#97] Cleanup redundant infra and tests

### DIFF
--- a/haskell/nettest/Main.hs
+++ b/haskell/nettest/Main.hs
@@ -6,7 +6,6 @@ module Main
 
 import Fmt (pretty)
 import Options.Applicative (execParser)
-import qualified Unsafe (fromJust)
 
 import qualified Data.Text.IO.Utf8 as Utf8
 import qualified Indigo.Contracts.Transferlist.External as External
@@ -68,7 +67,7 @@ main = do
     scenarioWithInternalTransferlist impl = do
       niComment impl "Stablecoin contract nettest scenarioWithInternalTransferlist"
       scNettestScenario
-        (Unsafe.fromJust . mkInitialStorage)
+        mkInitialStorage
         stablecoinContract
         originateTransferlistInternal
         Internal
@@ -78,7 +77,7 @@ main = do
     scenarioWithExternalTransferlist impl = do
       niComment impl "Stablecoin contract nettest scenarioWithExternalTransferlist"
       scNettestScenario
-        (Unsafe.fromJust . mkInitialStorage)
+        mkInitialStorage
         stablecoinContract
         (originateTransferlistExternal @m @capsM)
         External

--- a/haskell/nettest/Permit.hs
+++ b/haskell/nettest/Permit.hs
@@ -38,7 +38,7 @@ permitScenario stablecoinContract = uncapsNettest $ do
   (_, user1) <- createUser "Steve"
 
   comment "Originating contracts"
-  let storage = Unsafe.fromJust $ mkInitialStorage $
+  let storage = mkInitialStorage $
         addAccount (owner1 , ([], 1000)) $
           defaultOriginationParams
             { opOwner = owner1

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -42,9 +42,8 @@ extra-deps:
     https://gitlab.com/morley-framework/morley-ledgers.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    # TODO: update this to master
-    099082d778b8d2c25b6c9db9145f9745d0d77afe # sras/#5-sample-fa2-indigo
-  # nix-sha256: 1yy7fm5fj6m2mlrmj6c6lr5xb5l0pqq2y71ch3np7ml196iipz0i
+    47a94df200451d78d81cf0515f9328645a03bd22 # master
+  # nix-sha256: 0cx2an4kdgg9awd0y008afa6abihsy6rqldq2xxmyb2m20vdzgms
   subdirs:
     - code/morley-ledgers
     - code/morley-ledgers-test

--- a/haskell/stack.yaml.lock
+++ b/haskell/stack.yaml.lock
@@ -163,26 +163,26 @@ packages:
     version: 0.2.0.1
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     pantry-tree:
-      size: 1415
-      sha256: c99f1b81bcf6ccf2563fc212157f2d3a807a3cb3caabb1686392482273c9b9d1
-    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+      size: 1421
+      sha256: 4cb0661fe0a19b6c0d1c8c2eb8aa1a1127a3062312270ac9bdb9c97620e02c38
+    commit: 47a94df200451d78d81cf0515f9328645a03bd22
   original:
     subdir: code/morley-ledgers
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+    commit: 47a94df200451d78d81cf0515f9328645a03bd22
 - completed:
     subdir: code/morley-ledgers-test
     name: morley-ledgers-test
     version: 0.2.0.1
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     pantry-tree:
-      size: 1518
-      sha256: 9d5e2b8f0828e5699c845b0bcf436a45a73778d3fa42e96903f4b8225bb96a45
-    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+      size: 1751
+      sha256: 3fd9977d9bc1f41e46fe5c55e7909b66003f124b031c3dafc532a44803981338
+    commit: 47a94df200451d78d81cf0515f9328645a03bd22
   original:
     subdir: code/morley-ledgers-test
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+    commit: 47a94df200451d78d81cf0515f9328645a03bd22
 snapshots:
 - completed:
     size: 531707

--- a/haskell/test/SMT.hs
+++ b/haskell/test/SMT.hs
@@ -11,7 +11,6 @@ module SMT
 import qualified Data.Map as Map
 import Data.Typeable (cast)
 import Fmt
-import qualified Unsafe (fromJust)
 
 import Test.Tasty.QuickCheck
   (Arbitrary, Gen, Property, arbitrary, arbitraryBoundedEnum, choose, elements, shuffle, sublistOf,
@@ -498,7 +497,7 @@ stablecoinMichelsonModel
   -> ContractState
 stablecoinMichelsonModel contract cc@(ContractCall {..}) cs = let
   contractEnv = dummyContractEnv { ceSender = ccSender, ceAmount = unsafeMkMutez 0 }
-  initSt = Unsafe.fromJust $ mkInitialStorage $ ssToOriginationParams $ csStorage cs
+  initSt = mkInitialStorage $ ssToOriginationParams $ csStorage cs
   iResult = callEntrypoint contract cc initSt contractEnv
   in case iResult of
     Right iRes -> let

--- a/haskell/test/Stablecoin.hs
+++ b/haskell/test/Stablecoin.hs
@@ -28,9 +28,8 @@ import qualified Michelson.Typed as T
 import Stablecoin.Client.Contract (parseStablecoinContract)
 
 origination :: T.Contract (ToT SC.Parameter) (ToT Storage) -> OriginationFn SC.Parameter
-origination contract (mkInitialStorage -> Just storageVal) = pure . TAddress @SC.Parameter <$>
+origination contract (mkInitialStorage -> storageVal) = TAddress @SC.Parameter <$>
     tOriginate contract "Stablecoin contract" (toVal storageVal) (unsafeMkMutez 0)
-origination _ _ = pure Nothing
 
 spec_FA2 :: Spec
 spec_FA2 =


### PR DESCRIPTION
## Description

Currently we have some tests infra that looks for a specific configuration of permissions before running the tests. But this is no longer required as we are implementing specific FA2 behavior. So we can only implement such tests and can remove the test infra for permissions configuration check.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #97 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
