### PR TITLE
[#94] Implemented FA1.2 in stablecoin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@
 
 env:
   FETCH_CONTRACT:
-    "mkdir -p haskell/test/resources/ && buildkite-agent artifact download stablecoin.tz haskell/test/resources/ && buildkite-agent artifact download metadata.tz haskell/test/resources/ --step \"LIGO-contract\""
+    "mkdir -p haskell/test/resources/ && buildkite-agent artifact download stablecoin.tz haskell/test/resources/ && buildkite-agent artifact download stablecoin.fa1.2.tz haskell/test/resources/ && buildkite-agent artifact download metadata.tz haskell/test/resources/ --step \"LIGO-contract\""
   TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
 
 steps:
@@ -26,9 +26,12 @@ steps:
    commands:
      - nix-build -A tezos-contract -o stablecoin_raw.tz
      - nix run -f. morley -c morley optimize --contract stablecoin_raw.tz --output stablecoin.tz
+     - nix-build -A tezos-contract-fa1-2 -o stablecoin.fa1.2_raw.tz
+     - nix run -f. morley -c morley optimize --contract stablecoin.fa1.2_raw.tz --output stablecoin.fa1.2.tz
      - nix-build -A tezos-metadata-contract -o metadata.tz
    artifact_paths:
      - stablecoin.tz
+     - stablecoin.fa1.2.tz
      - metadata.tz
  - label: build library
    if: *not_scheduled

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ TAGS
 
 # We also ignore them in `haskell/test/resources/` because they are symlinked for tests.
 /haskell/test/resources/stablecoin.tz
+/haskell/test/resources/stablecoin.fa1.2.tz
 /haskell/test/resources/metadata.tz

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: build-ligo build-haskell
 # Compile LIGO contract into its michelson representation
 build-ligo:
 	$(MAKE_LIGO) stablecoin.tz
+	$(MAKE_LIGO) stablecoin.fa1.2.tz
 	$(MAKE_LIGO) metadata.tz
 
 # Compile LIGO contract and then build everything haskell-related (including tests and benchmarks)

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,13 @@ let
     buildPhase = "make stablecoin.tz";
     installPhase = "cp stablecoin.tz $out";
   };
+  tezos-contract-fa1-2 = pkgs.stdenv.mkDerivation {
+    name = "stablecoin.tz";
+    src = ./ligo;
+    nativeBuildInputs = [ ligo ];
+    buildPhase = "make stablecoin.fa1.2.tz";
+    installPhase = "cp stablecoin.fa1.2.tz $out";
+  };
   tezos-metadata-contract = pkgs.stdenv.mkDerivation {
     name = "stablecoin.tz";
     src = ./ligo;
@@ -77,5 +84,5 @@ in
   test = project.stablecoin.components.tests.stablecoin-test;
   nettest = project.stablecoin.components.tests.stablecoin-nettest;
   stablecoin-client = project.stablecoin.components.exes.stablecoin-client;
-  inherit tezos-contract tezos-metadata-contract tezos-client pkgs weeder-script morley;
+  inherit tezos-contract tezos-contract-fa1-2 tezos-metadata-contract tezos-client pkgs weeder-script morley;
 }

--- a/haskell/Makefile
+++ b/haskell/Makefile
@@ -28,9 +28,11 @@ endef
 
 define build_stablecoin_contract
 	$(MAKE_LIGO) stablecoin.tz
+	$(MAKE_LIGO) stablecoin.fa1.2.tz
 	$(MAKE_LIGO) metadata.tz
 	mkdir -p test/resources
 	$(MORLEY) optimize --contract "$(LIGO_DIR)/stablecoin.tz" --output "test/resources/stablecoin.tz"
+	$(MORLEY) optimize --contract "$(LIGO_DIR)/stablecoin.fa1.2.tz" --output "test/resources/stablecoin.fa1.2.tz"
 	cp "$(LIGO_DIR)/metadata.tz" "test/resources/metadata.tz"
 endef
 
@@ -79,4 +81,5 @@ lint:
 clean:
 	stack clean $(PACKAGE)
 	rm -f stablecoin.tz
+	rm -f stablecoin.fa1.2.tz
 	rm -f metadata.tz

--- a/haskell/nettest/FA1_2.hs
+++ b/haskell/nettest/FA1_2.hs
@@ -1,0 +1,79 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: MIT
+
+module FA1_2
+  ( fa1_2Scenario
+  ) where
+
+import qualified Data.Map as Map
+
+import Lorentz (BigMap(..), EntrypointRef(Call), TAddress(..), mkView, toVal)
+import Lorentz.Test.Consumer (contractConsumer)
+import Michelson.Typed (untypeValue)
+import qualified Michelson.Untyped as U
+import Morley.Nettest
+import Util.Named ((.!))
+
+import Lorentz.Contracts.StablecoinFA1_2 (Parameter, Storage(..))
+
+-- | This test runs each FA1.2 operation once.
+--
+-- It does not actually make any assertions (other than that the contract doesn't fail).
+-- Rather, its main purpose is to automate these operations so we can easily
+-- the gas/transaction costs.
+fa1_2Scenario :: U.Contract -> NettestScenario m
+fa1_2Scenario contract = uncapsNettest $ do
+  comment "-- FA1.2 tests --"
+
+  comment "Creating accounts"
+  nettest <- resolveNettestAddress
+  natConsumer <- originateSimple "natConsumer" [] (contractConsumer @Natural)
+  owner1 <- newAddress "Steve"
+  owner2 <- newAddress "Megan"
+
+  let balances = Map.fromList
+        [ (owner1, 10)
+        , (owner2, 10)
+        ]
+
+  let storage = Storage
+        { sDefaultExpiry = 1000
+        , sLedger = BigMap balances
+        , sMintingAllowances = mempty
+        , sSpenderAllowances = mempty
+        , sIsPaused = False
+        , sPermitCounter = 0
+        , sPermits = mempty
+        , sRoles = #roles .!
+            ( ( #master_minter .! nettest
+              , #owner .! nettest
+              )
+            , ( #pauser .! nettest
+              , #pending_owner_address .! Nothing
+              )
+            )
+        , sTransferlistContract = Nothing
+        , sTotalSupply = sum balances
+        }
+
+  comment "Originating FA1.2 contract"
+  contractAddr <- TAddress @Parameter <$>
+    originateUntypedSimple "Stablecoin FA1.2" (untypeValue $ toVal storage) contract
+
+  comment "Calling approve"
+  callFrom (AddressResolved owner1) contractAddr (Call @"Approve") (#spender .! owner2, #value .! 2)
+
+  comment "Calling getAllowance"
+  call contractAddr (Call @"GetAllowance") (mkView (#owner .! owner1, #spender .! owner2) natConsumer)
+
+  comment "Calling getBalance"
+  call contractAddr (Call @"GetBalance") (mkView (#owner .! owner1) natConsumer)
+
+  comment "Calling getTotalSupply"
+  call contractAddr (Call @"GetTotalSupply") (mkView () natConsumer)
+
+  comment "Calling transfer"
+  callFrom (AddressResolved owner1) contractAddr (Call @"Transfer") (#from .! owner1, #to .! owner2, #value .! 2)
+
+  comment "Calling pre-approved transfer"
+  callFrom (AddressResolved owner2) contractAddr (Call @"Transfer") (#from .! owner1, #to .! owner2, #value .! 2)

--- a/haskell/nettest/Main.hs
+++ b/haskell/nettest/Main.hs
@@ -4,6 +4,7 @@ module Main
   ( main
   ) where
 
+import Fmt (pretty)
 import Options.Applicative (execParser)
 import qualified Unsafe (fromJust)
 
@@ -19,6 +20,8 @@ import Morley.Nettest
 import Tezos.Address
 import Util.Named
 
+import FA1_2 (fa1_2Scenario)
+import qualified Lorentz.Contracts.StablecoinFA1_2 as FA1_2
 import Nettest (TransferlistType(External, Internal), scNettestScenario)
 import Permit (permitScenario)
 import Stablecoin.Client.Cleveland.Caps (runStablecoinClient)
@@ -94,3 +97,10 @@ main = do
     (ncMorleyClientConfig parsedConfig)
     (neMorleyClientEnv env)
     stablecoinClientScenario
+
+  -- Test the FA1.2 version of the stablecoin contract
+  stablecoinContractFA1_2 <-
+    case FA1_2.parseStablecoinContract of
+      Right c -> pure c
+      Left err -> fail $ pretty err
+  runNettestClient env (fa1_2Scenario stablecoinContractFA1_2)

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -26,6 +26,7 @@ library:
   dependencies:
     - morley-prelude
     - morley-client
+    - morley-ledgers
     - lorentz
     - morley
     - containers
@@ -59,6 +60,7 @@ tests:
     dependencies:
       - morley
       - morley-prelude
+      - morley-ledgers-test
       - lorentz
       - cleveland
       - tasty

--- a/haskell/src/Lorentz/Contracts/Stablecoin.hs
+++ b/haskell/src/Lorentz/Contracts/Stablecoin.hs
@@ -4,6 +4,9 @@
 module Lorentz.Contracts.Stablecoin
   ( ConfigureMinterParam
   , ChangeMasterMinterParam
+  , ChangePauserParam
+  , GetCounterParam
+  , SetTransferlistParam
   , TokenMetadata
   , TokenMetadataRegistryAddress
   , RemoveMinterParam
@@ -14,6 +17,7 @@ module Lorentz.Contracts.Stablecoin
   , BurnParams
   , ParameterC
   , Parameter (..)
+  , Roles
   , Storage
   , TransferOwnershipParam
   , OwHook(..)

--- a/haskell/src/Lorentz/Contracts/StablecoinFA1_2.hs
+++ b/haskell/src/Lorentz/Contracts/StablecoinFA1_2.hs
@@ -1,0 +1,79 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: MIT
+
+module Lorentz.Contracts.StablecoinFA1_2
+ ( Storage(..)
+ , Parameter(..)
+ , parseStablecoinContract
+ ) where
+
+import Data.FileEmbed (embedStringFile)
+
+import Lorentz
+import qualified Lorentz.Contracts.Spec.ApprovableLedgerInterface as AL
+import qualified Lorentz.Contracts.Stablecoin as S
+import Michelson.Parser (ParserException)
+import Michelson.Runtime (parseExpandContract)
+import qualified Michelson.Untyped as U
+
+-- | Parse the stablecoin contract.
+parseStablecoinContract :: Either ParserException U.Contract
+parseStablecoinContract =
+  parseExpandContract
+    (Just "./test/resources/stablecoin.fa1.2.tz")
+    $(embedStringFile "./test/resources/stablecoin.fa1.2.tz")
+
+data Storage = Storage
+  { sDefaultExpiry :: S.Expiry
+  , sLedger :: BigMap Address Natural
+  , sMintingAllowances :: Map Address Natural
+  , sIsPaused :: Bool
+  , sPermitCounter :: Natural
+  , sPermits :: BigMap Address S.UserPermits
+  , sRoles :: S.Roles
+  , sSpenderAllowances :: BigMap (Address, Address) Natural
+  , sTotalSupply :: Natural
+  , sTransferlistContract :: Maybe Address
+  }
+
+deriving anyclass instance IsoValue Storage
+deriving anyclass instance HasAnnotation Storage
+$(customGeneric "Storage" $ withDepths
+    [ cstr @0
+      [ fld @4 -- sDefaultExpiry
+      , fld @4 -- sLedger
+      , fld @4 -- sMintingAllowances
+      , fld @4 -- sIsPaused
+      , fld @4 -- sPermitCounter
+      , fld @4 -- sPermits
+      , fld @4 -- sRoles
+      , fld @4 -- sSpenderAllowances
+      , fld @2 -- sTotalSupply
+      , fld @2 -- sTransferlistContract
+      ]
+    ]
+  )
+
+data Parameter
+  = Accept_ownership
+  | Burn S.BurnParams
+  | Change_master_minter S.ChangeMasterMinterParam
+  | Change_pauser S.ChangePauserParam
+  | Configure_minter S.ConfigureMinterParam
+  | Get_counter S.GetCounterParam
+  | Get_default_expiry S.GetDefaultExpiryParam
+  | Mint S.MintParams
+  | Pause
+  | Permit S.PermitParam
+  | Remove_minter S.RemoveMinterParam
+  | Revoke S.RevokeParams
+  | Set_expiry S.SetExpiryParam
+  | Set_transferlist S.SetTransferlistParam
+  | Transfer_ownership S.TransferOwnershipParam
+  | Unpause
+  | Call_FA1_2 AL.Parameter
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance ParameterHasEntrypoints Parameter where
+  type ParameterEntrypointsDerivation Parameter = EpdRecursive

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -37,3 +37,14 @@ extra-deps:
 - named-0.3.0.1@sha256:69b9722301201f8ed8abc89c4595e22c746e944bf4cdfafa8b21b14d336b26d1,2233
 - vinyl-0.12.1@sha256:43456d4b3009646eee63953cbe539f1f4d0caf8bc3c25e841117e712836508f3,3790
 - cryptonite-0.27
+
+- git:
+    https://gitlab.com/morley-framework/morley-ledgers.git
+    # ^ CI cannot use ssh, so we use http clone here
+  commit:
+    # TODO: update this to master
+    099082d778b8d2c25b6c9db9145f9745d0d77afe # sras/#5-sample-fa2-indigo
+  # nix-sha256: 1yy7fm5fj6m2mlrmj6c6lr5xb5l0pqq2y71ch3np7ml196iipz0i
+  subdirs:
+    - code/morley-ledgers
+    - code/morley-ledgers-test

--- a/haskell/stack.yaml.lock
+++ b/haskell/stack.yaml.lock
@@ -157,6 +157,32 @@ packages:
       sha256: 1a63bb79748aeb2c0312d6a166fe8436a139929b017bf208f002e79073d21966
   original:
     hackage: cryptonite-0.27
+- completed:
+    subdir: code/morley-ledgers
+    name: morley-ledgers
+    version: 0.2.0.1
+    git: https://gitlab.com/morley-framework/morley-ledgers.git
+    pantry-tree:
+      size: 1415
+      sha256: c99f1b81bcf6ccf2563fc212157f2d3a807a3cb3caabb1686392482273c9b9d1
+    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+  original:
+    subdir: code/morley-ledgers
+    git: https://gitlab.com/morley-framework/morley-ledgers.git
+    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+- completed:
+    subdir: code/morley-ledgers-test
+    name: morley-ledgers-test
+    version: 0.2.0.1
+    git: https://gitlab.com/morley-framework/morley-ledgers.git
+    pantry-tree:
+      size: 1518
+      sha256: 9d5e2b8f0828e5699c845b0bcf436a45a73778d3fa42e96903f4b8225bb96a45
+    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
+  original:
+    subdir: code/morley-ledgers-test
+    git: https://gitlab.com/morley-framework/morley-ledgers.git
+    commit: 099082d778b8d2c25b6c9db9145f9745d0d77afe
 snapshots:
 - completed:
     size: 531707

--- a/haskell/test-common/Lorentz/Contracts/Test/Common.hs
+++ b/haskell/test-common/Lorentz/Contracts/Test/Common.hs
@@ -1,6 +1,8 @@
 -- SPDX-FileCopyrightText: 2020 TQ Tezos
 -- SPDX-License-Identifier: MIT
 
+{-# LANGUAGE PackageImports #-}
+
 -- | Test commons for stablecoin test suite
 
 module Lorentz.Contracts.Test.Common
@@ -45,7 +47,7 @@ import Data.List.NonEmpty ((!!))
 import qualified Data.Map as Map
 
 import qualified Indigo.Contracts.Transferlist.Internal as Transferlist
-import Lorentz.Contracts.Spec.FA2Interface as FA2
+import "stablecoin" Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin as SC
 import Lorentz.Test
 import Lorentz.Value

--- a/haskell/test/Lorentz/Contracts/Test/FA1_2.hs
+++ b/haskell/test/Lorentz/Contracts/Test/FA1_2.hs
@@ -1,0 +1,55 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: MIT
+
+-- | Tests for FA1.2 interface.
+-- https://gitlab.com/tzip/tzip/-/blob/667f925471728bb8e81fbd30b93a171e401b6dc1/proposals/tzip-7/tzip-7.md
+
+module Lorentz.Contracts.Test.FA1_2
+  ( spec_fa1_2
+  ) where
+
+import qualified Data.Map as Map
+import Fmt (pretty)
+import Test.Hspec (Spec, describe)
+
+import Lorentz (Address, BigMap(..), TAddress(..), toMutez, toVal)
+import Lorentz.Contracts.Test.ApprovableLedger (AlSettings(..), approvableLedgerSpec)
+import Michelson.Test.Integrational
+import Michelson.Typed (untypeValue)
+import Util.Named ((.!))
+
+import Lorentz.Contracts.StablecoinFA1_2 (Parameter, Storage(..), parseStablecoinContract)
+
+alOriginationFunction :: Address -> AlSettings -> IntegrationalScenarioM (TAddress Parameter)
+alOriginationFunction adminAddr (AlInitAddresses addrBalances) = do
+  stablecoionContract <-
+    case parseStablecoinContract of
+      Right c -> pure c
+      Left err -> integrationalFail . CustomTestError $ pretty err
+
+  let storage = Storage
+        { sDefaultExpiry = 1000
+        , sLedger = BigMap $ Map.filter (/= 0) $ Map.fromList $ addrBalances
+        , sMintingAllowances = mempty
+        , sSpenderAllowances = mempty
+        , sIsPaused = False
+        , sPermitCounter = 0
+        , sPermits = mempty
+        , sRoles = #roles .!
+            ( ( #master_minter .! adminAddr
+              , #owner .! adminAddr
+              )
+            , ( #pauser .! adminAddr
+              , #pending_owner_address .! Nothing
+              )
+            )
+        , sTransferlistContract = Nothing
+        , sTotalSupply = sum $ snd <$> addrBalances
+        }
+
+  TAddress @Parameter <$> originate stablecoionContract "" (untypeValue $ toVal storage) (toMutez 0)
+
+spec_fa1_2 :: Spec
+spec_fa1_2 =
+  describe "FA1.2 SMT" $
+    approvableLedgerSpec alOriginationFunction

--- a/haskell/test/Lorentz/Contracts/Test/FA2.hs
+++ b/haskell/test/Lorentz/Contracts/Test/FA2.hs
@@ -1,6 +1,8 @@
 -- SPDX-FileCopyrightText: 2020 TQ Tezos
 -- SPDX-License-Identifier: MIT
 
+{-# LANGUAGE PackageImports #-}
+
 -- | Tests for FA2 interface.
 -- https://gitlab.com/tzip/tzip/-/blob/131b46dd89675bf030489ded9b0b3f5834b70eb6/proposals/tzip-12/tzip-12.md
 
@@ -17,7 +19,7 @@ import Data.Map as M (lookup)
 import Test.Hspec (Spec, describe, it)
 
 import Lorentz (mkView)
-import Lorentz.Contracts.Spec.FA2Interface as FA2
+import "stablecoin" Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin (pattern StorageLedger)
 import Lorentz.Contracts.Test.Common
 import Lorentz.Test

--- a/haskell/test/Lorentz/Contracts/Test/Management.hs
+++ b/haskell/test/Lorentz/Contracts/Test/Management.hs
@@ -1,6 +1,8 @@
 -- SPDX-FileCopyrightText: 2020 TQ Tezos
 -- SPDX-License-Identifier: MIT
 
+{-# LANGUAGE PackageImports #-}
+
 -- | Tests for management entrypoints of stablecoin smart-contract
 
 module Lorentz.Contracts.Test.Management
@@ -19,7 +21,7 @@ import Test.Hspec (Spec, describe, it)
 import qualified Indigo.Contracts.Transferlist.Internal as Transferlist
 import Lorentz (mkView, mt)
 import Lorentz.Address
-import Lorentz.Contracts.Spec.FA2Interface as FA2
+import "stablecoin" Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin
 import Lorentz.Contracts.Test.Common
 import Lorentz.Test

--- a/haskell/test/Lorentz/Contracts/Test/Permit.hs
+++ b/haskell/test/Lorentz/Contracts/Test/Permit.hs
@@ -5,6 +5,7 @@
 -- https://gitlab.com/morley-framework/morley/-/issues/350
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-unused-do-bind #-}
+{-# LANGUAGE PackageImports #-}
 
 -- | Tests for permit functionality of stablecoin smart-contract
 
@@ -28,7 +29,7 @@ import qualified Tezos.Crypto.Secp256k1 as Secp256k1
 import Tezos.Crypto.Util (deterministic)
 import Util.Named
 
-import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
+import qualified "stablecoin" Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin
 
 import Lorentz.Contracts.Test.Common

--- a/haskell/test/SMT.hs
+++ b/haskell/test/SMT.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: MIT
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
+{-# LANGUAGE PackageImports #-}
 
 module SMT
   ( smtProperty
@@ -22,7 +23,7 @@ import Tezos.Core (unsafeMkMutez)
 import Lorentz
   (Address, EntrypointRef(Call), GetEntrypointArgCustom, IsoValue(..), TAddress(TAddress), arg,
   parameterEntrypointCallCustom)
-import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
+import qualified "stablecoin" Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin
 import Lorentz.Contracts.Test.Common
 import Michelson.Interpret

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -6,11 +6,14 @@ LIGO ?= ligo
 
 # All files with `.ligo` extension are considered source files.
 # Recompilation will be triggered only if they are changed.
-sources = stablecoin/*.ligo
+sources = stablecoin/**/*.ligo
 
 # Compile LIGO contract into its michelson representation
 stablecoin.tz: $(sources)
 	$(LIGO) compile-contract --syntax pascaligo stablecoin/core.ligo stablecoin_main > stablecoin.tz
+
+stablecoin.fa1.2.tz: $(sources)
+	$(LIGO) compile-contract --syntax pascaligo stablecoin/fa1.2/core.ligo stablecoin_main > stablecoin.fa1.2.tz
 
 # Compile metadata LIGO contract into its michelson representation
 metadata.tz: $(sources)

--- a/ligo/stablecoin/fa1.2/actions.ligo
+++ b/ligo/stablecoin/fa1.2/actions.ligo
@@ -1,0 +1,843 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: MIT
+
+(*
+ * Root entrypoints for stablecoin smart-contract
+ *)
+
+#include "../operator.ligo"
+#include "../permit.ligo"
+
+(* ------------------------------------------------------------- *)
+
+(*
+ * Helpers
+ *)
+
+(*
+ * Helper function used to reduce
+ *  `if (condition) then failwith (message) else skip;`
+ * appearances.
+ *)
+function fail_on
+  ( const condition : bool
+  ; const message   : string
+  ) : unit is if condition then failwith (message) else unit
+
+(*
+ * Authorizes current contract owner and fails otherwise.
+ *)
+function authorize_contract_owner
+  ( const store : storage
+  ; const full_param : closed_parameter
+  ) : storage is
+  sender_check(store.roles.owner, store, full_param, "NOT_CONTRACT_OWNER")
+
+(*
+ * Ensures that sender is current pending contract owner.
+ *)
+function authorize_pending_owner
+  ( const store : storage
+  ; const full_param : closed_parameter
+  ) : storage * address is case store.roles.pending_owner of
+    Some (pending_owner) ->
+      ( sender_check(pending_owner, store, full_param, "NOT_PENDING_OWNER")
+      , pending_owner
+      )
+    | None -> (failwith ("NO_PENDING_OWNER_SET") : storage * address)
+    end
+
+(*
+ * Authorizes contract pauser and fails otherwise.
+ *)
+function authorize_pauser
+  ( const store : storage
+  ; const full_param : closed_parameter
+  ) : storage is
+  sender_check(store.roles.pauser, store, full_param, "NOT_PAUSER")
+
+(*
+ * Authorizes master_minter and fails otherwise.
+ *)
+function authorize_master_minter
+  ( const store : storage
+  ; const full_param : closed_parameter
+  ) : storage is
+  sender_check(store.roles.master_minter, store, full_param, "NOT_MASTER_MINTER")
+
+(*
+ * Authorizes minter and fails otherwise.
+ *)
+function authorize_minter
+  ( const store : storage
+  ) : unit is case store.minting_allowances[Tezos.sender] of
+    Some (u) -> unit
+  | None -> failwith ("NOT_MINTER")
+  end
+
+(*
+ * Helper that fails if contract is paused.
+ *)
+function ensure_not_paused
+  ( const store : storage
+  ) : unit is
+  fail_on
+    ( store.paused
+    , "CONTRACT_PAUSED"
+    )
+
+(*
+ * Helper that fails if contract is not paused.
+ *)
+function ensure_is_paused
+  ( const store : storage
+  ) : unit is
+  fail_on
+    ( not store.paused
+    , "CONTRACT_NOT_PAUSED"
+    )
+
+(*
+ * Increases the balance of an address associated with it
+ * and present in ledger. If not, creates a new address with
+ * that balance given.
+ *)
+function credit_to
+  ( const parameter : mint_param_
+  ; const store     : storage
+  ) : storage is block
+{ var updated_balance : nat := 0n
+; case store.ledger[parameter.to_] of
+    Some (ledger_balance) -> updated_balance := ledger_balance
+  | None -> skip
+  end
+; updated_balance := updated_balance + parameter.amount
+; const updated_ledger : ledger =
+    Big_map.update(parameter.to_, Some (updated_balance), store.ledger)
+} with store with record [ ledger = updated_ledger ]
+
+type debit_param_ is record
+  from_  : address
+; amount : nat
+end
+
+(*
+ * Decreases the balance of an address that is present in
+ * ledger. Fails if it's not or given address has not enough
+ * tokens to be burn from.
+ *)
+function debit_from
+  ( const parameter : debit_param_
+  ; const store     : storage
+  ) : storage is block
+{ var updated_ledger : ledger := store.ledger
+
+; const curr_balance : nat = case store.ledger[parameter.from_] of
+    Some (ledger_balance) -> ledger_balance
+  | None -> 0n // Interpret non existant account as zero balance as per FA2
+  end
+
+ ; const updated_balance: option(nat) = case is_nat(curr_balance - parameter.amount) of
+       Some (ub) -> if ub = 0n then (None : option(nat)) else Some(ub) // If balance is 0 set None to remove it from ledger
+     | None -> (failwith ("FA2_INSUFFICIENT_BALANCE") : option(nat))
+     end
+ ; updated_ledger := Big_map.update(parameter.from_, updated_balance, updated_ledger)
+
+} with store with record [ ledger = updated_ledger ]
+
+(*
+ * Converts a transfer item into a transferlist transfer item
+ *)
+function convert_to_transferlist_transfer
+  ( const tp : transfer_param
+  ) : transferlist_transfer_item is
+    ( tp.0
+    , List.map
+          ( function
+              ( const dst: transfer_destination
+              ) : address is dst.0
+          , tp.1
+          )
+    )
+
+(*
+ * Calls `assert_transfer` of the provided transferlist contract using
+ * the provided transfer_descriptors.
+ *)
+function call_assert_transfers
+  ( const opt_sl_address : option(address)
+  ; const transfer_params : transfer_params
+  ) : list(operation) is block
+  { const operations: list(operation) =
+      case opt_sl_address of
+        Some (sl_address) ->
+          case (Tezos.get_entrypoint_opt ("%assertTransfers", sl_address) : option(contract(transferlist_assert_transfers_param))) of
+            Some (sl_caddress) ->
+              Tezos.transaction
+                ( List.map(convert_to_transferlist_transfer, transfer_params)
+                , 0mutez
+                , sl_caddress) # (nil : list(operation))
+            | None -> (failwith ("BAD_TRANSFERLIST_CONTRACT") : list(operation))
+            end
+        | None -> (nil : list(operation))
+        end
+  } with operations
+
+(*
+ * Calls `Assert_receivers` of the provided transferlist contract using
+ * the provided transfer_descriptors.
+ *)
+function call_assert_receivers
+  ( const opt_sl_address : option(address)
+  ; const receivers : list(address)
+  ) : list(operation) is block
+  {
+    const ops_in : list(operation) = nil
+  ; const operations:list(operation) =
+      case opt_sl_address of
+        Some (sl_address) ->
+          case (Tezos.get_entrypoint_opt ("%assertReceivers", sl_address) : option(contract(transferlist_assert_receivers_param))) of
+            Some (sl_caddress) ->
+              Tezos.transaction
+                ( receivers
+                , 0mutez
+                , sl_caddress) # ops_in
+            | None -> (failwith ("BAD_TRANSFERLIST_CONTRACT") : list(operation))
+            end
+      | None -> ops_in
+      end
+  } with operations
+
+
+(*
+ * Returns `True` if all booleans in the list are `True`,
+ * or `False` otherwise.
+ *)
+function all(const xs: list(bool)): bool is
+  List.fold
+    ( function(const acc: bool; const x: bool) is acc and x
+    , xs
+    , True
+    )
+
+(*
+ * Assert that all addresses in a list are equal,
+ * fails with `err_msg` otherwise.
+ *
+ * If the list is empty, returns `None`,
+ * otherwise returns `Some` with the unique address.
+ *)
+function all_equal
+  ( const addrs: list(address)
+  ; const err_msg: string
+  ) : option(address) is
+  case addrs of
+  | nil -> (None : option(address))
+  | first # rest ->
+      block {
+        List.iter
+          ( function (const addr : address): unit is
+              if addr =/= first
+                then failwith (err_msg)
+                else Unit
+          , rest
+          )
+      } with Some(first)
+  end
+
+(* ------------------------------------------------------------- *)
+
+(*
+ * FA2-specific entrypoints
+ *)
+
+(*
+ * Verify the sender of an `transfer` action.
+ *
+ * The check is successful if either of these is true:
+ * 1) The sender is either the owner or an approved operator for each and every
+ *    account from which funds will be withdrawn.
+ * 2) All transfers withdraw funds from a single account, and the account owner
+ *    has issued a permit allowing this call to go through.
+ *)
+function transfer_sender_check
+  ( const params : transfer_params
+  ; const store : storage
+  ; const full_param : closed_parameter
+  ) : storage is block
+{ // check if the sender is either the owner or an approved operator for all transfers
+  const is_approved_operator_for_all : bool =
+    all(
+      List.map(
+        function(const p : transfer_param) : bool is is_approved_operator(p, store.operators),
+        params
+      )
+    )
+} with
+    if is_approved_operator_for_all then
+      store
+    else
+      case params of
+        nil -> store
+      | first_param # rest -> block {
+          // check whether `from_` has issued a permit
+          const from_: address = first_param.0
+        ; const updated_store : storage = sender_check(from_, store, full_param, "FA2_NOT_OPERATOR")
+          // check that all operations relate to the same owner.
+        ; List.iter
+            ( function (const param : transfer_param): unit is
+                if param.0 =/= from_
+                  then failwith ("FA2_NOT_OPERATOR")
+                  else Unit
+            , rest
+            )
+        } with updated_store
+      end
+
+(*
+ * Initiates transfers from a given list of parameters. Fails
+ * if one of the transfer does. Otherwise this function returns
+ * updated storage and a list of transactions that call transfer
+ * hooks if such provided for associated addresses.
+ *)
+function transfer
+  ( const params : transfer_params
+  ; const store  : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ ensure_not_paused (store)
+; const store : storage = transfer_sender_check(params, store, full_param)
+
+; const sender_addr : address = Tezos.sender
+
+; function make_transfer
+    ( const acc       : entrypoint
+    ; const parameter : transfer_param
+    ) : entrypoint is block
+  { function transfer_tokens
+      ( const accumulator : storage
+      ; const destination : transfer_destination
+      ) : storage is block
+    { validate_token_type (destination.1.0)
+    ; const debit_param_ : debit_param_ = record
+      [ from_  = parameter.0
+      ; amount = destination.1.1
+      ]
+    ; const credit_param_ : mint_param_ = record
+      [ to_    = destination.0
+      ; amount = destination.1.1
+      ]
+    ; const debited_storage : storage =
+        debit_from (debit_param_, accumulator)
+    ; const credited_storage : storage =
+        credit_to (credit_param_, debited_storage)
+    } with credited_storage
+
+  ; const operator : address = parameter.0
+  ; const txs : list (transfer_destination) = parameter.1
+
+  ; const upd : list (operation) =
+      call_assert_transfers
+        ( store.transferlist_contract
+        , params
+        )
+  ; const ups : storage =
+      List.fold (transfer_tokens, txs, acc.1)
+  } with (merge_operations (upd, acc.0), ups)
+} with List.fold (make_transfer, params, ((nil : list (operation)), store))
+
+(*
+ * Retrieves a list of `balance_of` items that is specified for multiple
+ * token types in FA2 spec and leaves the storage untouched. In reality
+ * we restrict all of them to be of `default_token_id`. Fails if one of
+ * the parameters address to non-default token id.
+ *)
+function balance_of
+  ( const parameter : balance_of_params
+  ; const store     : storage
+  ) : entrypoint is block
+{ function retreive_balance
+    ( const request : balance_of_request
+    ) : balance_of_response is block
+  { validate_token_type (request.token_id)
+  ; var retreived_balance : nat := 0n
+  ; case Big_map.find_opt (request.owner, store.ledger) of
+      Some (ledger_balance) -> retreived_balance := ledger_balance
+    | None -> skip
+    end
+  } with (request, retreived_balance)
+; const responses : list (balance_of_response) =
+    List.map (retreive_balance, parameter.0)
+; const transfer_operation : operation =
+    Tezos.transaction (responses, 0mutez, parameter.1)
+} with (list [transfer_operation], store)
+
+(*
+ * Returns address of the contract that holds tokens metadata.
+ * Since our contract holds its own metadata, then it always
+ * returns `SELF` address.
+ *)
+function token_metadata_registry
+  ( const parameter : token_metadata_registry_params
+  ; const store     : storage
+  ) : entrypoint is
+  ( list [Tezos.transaction
+    ( store.token_metadata_registry
+    , 0mutez
+    , parameter
+    )
+  ]
+  , store
+  )
+
+(*
+ * Add or remove operators for provided owners.
+ *)
+function update_operators_action
+  ( const params : update_operator_params
+  ; const store : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const owners : list(address) = List.map(get_owner, params)
+
+// A user can only modify their own operators.
+// So we check that all operations affect the same `owner`,
+// and that the sender *is* the owner or the owner has issued a permit.
+; const store : storage =
+    case all_equal(owners, "NOT_TOKEN_OWNER") of
+    | None -> store
+    | Some(owner) -> sender_check(owner, store, full_param, "NOT_TOKEN_OWNER")
+    end
+
+; const updated_operators : operators =
+    update_operators (params, store.operators)
+} with
+  ( (nil : list (operation))
+  , store with record [ operators = updated_operators ]
+  )
+
+(*
+ * Retrieves a boolean of whether the given address is an operator
+ * for `owner` address and remains the store untouched
+ *)
+function is_operator_action
+  ( const parameter : is_operator_params
+  ; const store     : storage
+  ) : entrypoint is
+  ( list [is_operator (parameter, store.operators)]
+  , store
+  )
+
+(*
+ * Pauses whole contract in order to prevent all transferring, burning,
+ * minting and allowance operations. All other operations remain
+ * unaffected. Fails if the contract is already paused.
+ *)
+function pause
+  ( const parameter : pause_params
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ ensure_not_paused (store)
+; const store: storage = sender_check(store.roles.pauser, store, full_param, "NOT_PAUSER")
+} with
+  ( (nil : list (operation))
+  , store with record [paused = True]
+  )
+
+(*
+ * Unpauses whole contract so that all transferring, burning, minting and
+ * allowance operations can be performed. Fails if the contract is already
+ * unpaused.
+ *)
+function unpause
+  ( const parameter : unpause_params
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ ensure_is_paused (store)
+; const store: storage = sender_check(store.roles.pauser, store, full_param, "NOT_PAUSER")
+} with
+  ( (nil : list (operation))
+  , store with record [paused = False]
+  )
+
+(*
+ * Adds minter to minting allowances map setting its allowance
+ * to 0. Resets the allowance if associated address is already
+ * present. Fails if sender is not master minter.
+ *)
+function configure_minter
+  ( const parameter : configure_minter_params
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ ensure_not_paused (store)
+; const store : storage = authorize_master_minter (store, full_param)
+; const present_minting_allowance : option (nat) =
+    store.minting_allowances[parameter.0]
+; const minter_limit : nat = 12n
+; case parameter.1.0 of
+    None -> case present_minting_allowance of
+      Some (u) -> failwith ("CURRENT_ALLOWANCE_REQUIRED")
+    | None ->
+        // We are adding a new minter. Check the minter limit is not exceeded.
+        if Map.size(store.minting_allowances) >= minter_limit then failwith ("MINTER_LIMIT_REACHED") else skip
+    end
+  | Some (current_minting_allowance) ->
+      case present_minting_allowance of
+        Some (allowance) -> if allowance =/= current_minting_allowance
+          then failwith ("ALLOWANCE_MISMATCH")
+          else skip
+      | None -> failwith ("ADDR_NOT_MINTER")
+      end
+  end
+} with
+  ( (nil : list (operation))
+  , store with record
+      [ minting_allowances = Map.update
+          ( parameter.0
+          , Some (parameter.1.1)
+          , store.minting_allowances
+          )
+      ]
+  )
+
+(*
+ * Removes minter from minting allowances map. Fails if minter
+ * is not present. Fails if sender is not master minter.
+ *)
+function remove_minter
+  ( const parameter : remove_minter_params
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const store : storage = authorize_master_minter (store, full_param)
+; case store.minting_allowances[parameter] of
+    Some (u) -> skip
+  | None -> failwith ("ADDR_NOT_MINTER")
+  end
+} with
+  ( (nil : list (operation))
+  , store with record
+      [ minting_allowances = Big_map.remove
+          ( parameter
+          , store.minting_allowances
+          )
+      ]
+  )
+
+(*
+ * Produces tokens to a wallet associated with the given address
+ *)
+function mint
+  ( const parameters : mint_params
+  ; const store      : storage
+  ) : entrypoint is block
+{ ensure_not_paused (store)
+; authorize_minter (store)
+
+; const senderAddress : address = Tezos.sender
+
+; function mint_tokens
+    ( const accumulator       : storage
+    ; const mint_param        : mint_param
+    ; const current_allowance : nat
+    ) : storage is block
+  { const unwrapped_parameter : mint_param_ =
+      Layout.convert_from_right_comb ((mint_param : mint_param))
+  ; const updated_allowance : nat =
+      case is_nat (current_allowance - unwrapped_parameter.amount) of
+        Some (n) -> n
+      | None -> (failwith ("ALLOWANCE_EXCEEDED") : nat)
+      end
+  ; const updated_allowances : minting_allowances =
+      Big_map.update (Tezos.sender, Some (updated_allowance), accumulator.minting_allowances)
+  ; const updated_store : storage = accumulator with record
+      [ minting_allowances = updated_allowances
+      ]
+  } with credit_to (unwrapped_parameter, updated_store)
+
+; const receivers : list(address) =
+    List.map
+      ( function
+          ( const mint_param: mint_param
+          ) : address is mint_param.0
+      , parameters
+      )
+
+; const upds : list(operation) = call_assert_receivers
+    ( store.transferlist_contract
+    , Tezos.sender # receivers
+    )
+
+} with
+  ( upds
+  , List.fold
+      ( function
+          ( const accumulator : storage
+          ; const mint_param  : mint_param
+          ) : storage is case accumulator.minting_allowances[senderAddress] of
+            None -> (failwith ("NOT_MINTER") : storage)
+          | Some (current_allowance) ->
+              mint_tokens (accumulator, mint_param, current_allowance)
+          end
+      , parameters
+      , store
+      )
+  )
+
+(*
+ * Decreases balance of tokens by the given amount
+ *)
+function burn
+  ( const parameters : burn_params
+  ; const store      : storage
+  ) : entrypoint is block
+{ ensure_not_paused (store)
+; authorize_minter (store)
+; const sender_address : address = Tezos.sender
+; function burn_tokens
+    ( const accumulator : storage
+    ; const burn_amount : nat
+    ) : storage is block
+  { const debited_storage : storage = debit_from
+      ( record
+          [ from_ = sender_address
+          ; amount = burn_amount
+          ]
+      , accumulator
+      )
+  } with debited_storage
+
+; const upds : list(operation) = call_assert_receivers
+    ( store.transferlist_contract
+    , Tezos.sender # nil
+    )
+
+} with
+  ( upds
+  , List.fold (burn_tokens, parameters, store)
+  )
+
+(*
+ * Sets contract owner to a new address
+ *)
+function transfer_ownership
+  ( const parameter : transfer_ownership_param
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const store : storage = authorize_contract_owner (store, full_param)
+} with
+  ( (nil : list (operation))
+  , store with record [roles.pending_owner = Some (parameter)]
+  )
+
+(*
+ * When pending contract owner calls this entrypoint, the address
+ * receives owner privileges for contract
+ *)
+function accept_ownership
+  ( const parameter : accept_ownership_param
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const auth_result : (storage * address) = authorize_pending_owner (store, full_param)
+} with
+  ( (nil : list (operation))
+  , auth_result.0 with record
+      [ roles.pending_owner = (None : option (address))
+      ; roles.owner = auth_result.1
+      ]
+  )
+
+(*
+ * Moves master minter priveleges to a new address.
+ * Fails if sender is not contract owner.
+ *)
+function change_master_minter
+  ( const parameter : change_master_minter_param
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const store : storage = authorize_contract_owner (store, full_param)
+} with
+  ( (nil : list (operation))
+  , store with record [ roles.master_minter = parameter ]
+  )
+
+(*
+ * Moves pauser priveleges to a new address.
+ * Fails if sender is not contract owner.
+ *)
+function change_pauser
+  ( const parameter : change_pauser_param
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const store : storage = authorize_contract_owner (store, full_param)
+} with
+  ( (nil : list (operation))
+  , store with record [ roles.pauser = parameter ]
+  )
+
+(*
+ * Sets transferlist contract address
+ *)
+function set_transferlist
+  ( const parameter : set_transferlist_param
+  ; const store     : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const store : storage = authorize_contract_owner (store, full_param)
+
+; case parameter of
+    Some (sl_address) ->
+      case (Tezos.get_entrypoint_opt ("%assertTransfers", sl_address) : option(contract(transferlist_assert_transfers_param))) of
+        Some (sl_caddress) -> case (Tezos.get_entrypoint_opt ("%assertReceivers", sl_address) : option(contract(transferlist_assert_receivers_param))) of
+          Some (sl_caddress) -> skip
+        | None -> failwith ("BAD_TRANSFERLIST")
+        end
+      | None -> failwith ("BAD_TRANSFERLIST")
+      end
+  | None -> skip
+  end
+
+} with
+  ( (nil : list (operation))
+  , store with record [ transferlist_contract = parameter ]
+  )
+
+(*
+ * Creates a new permit, allowing any user to act on behalf of the user
+ * who signed the permit.
+ *)
+function add_permit
+  ( const parameter: permit_param
+  ; const store    : storage
+  ) : entrypoint is block
+{ const key : key = parameter.0
+; const signature : signature = parameter.1.0
+; const permit : blake2b_hash = parameter.1.1
+; const issuer: address = Tezos.address(Tezos.implicit_account(Crypto.hash_key(key)))
+
+// form the structure that is to be signed by pairing self contract address, chain id, counter
+// and permit hash and pack it to get bytes.
+; const to_sign : bytes = Bytes.pack (((Tezos.self_address, Tezos.chain_id), (store.permit_counter, permit)))
+
+// check the included signature against public_key from parameter and bytes derived from the
+// operation in parameter.
+; const store : storage =
+    if (Crypto.check (key, signature, to_sign)) then
+      store with record
+        [ permit_counter = store.permit_counter + 1n
+        ; permits =
+            delete_expired_permits(store.default_expiry, issuer,
+              insert_permit(issuer, permit, store.permits)
+            )
+        ]
+    else block {
+      // We're using Embedded Michelson here to get around the limitation that,
+      // currently, Ligo's `failwith` only supports strings and numeric types.
+      // https://ligolang.org/docs/advanced/embedded-michelson/
+      //
+      // Once this MR is merged, we should be able to use Ligo's `failwith`:
+      // https://gitlab.com/ligolang/ligo/-/issues/193
+      const failwith_ : (string * bytes -> storage) =
+        [%Michelson ({| { FAILWITH } |} : string * bytes -> storage)];
+    } with failwith_(("MISSIGNED", to_sign))
+} with
+    ( (nil : list(operation))
+    , store
+    )
+
+(*
+ * Deletes the given permits.
+ *
+ * Only the issuer X of a permit can revoke X's permits.
+ * Otherwise, X can issue a separate permit allowing other users to revoke X's permits.
+ *
+ * This operation does not fail if a given permit is not found.
+ *
+ * Fails with 'NOT_PERMIT_ISSUER' if:
+ *   a) the sender is not the issuer of any of the given permits,
+ *   b) and the issuer has not issued a permit allowing others to revoke their permits
+ *)
+function revoke_permits
+  ( const params: revoke_params
+  ; const store : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint is block
+{ const issuers : list(address) =
+    List.map(function(const p: revoke_param): address is p.1, params)
+
+; const store : storage =
+    case all_equal(issuers, "NOT_PERMIT_ISSUER") of
+    | None -> store
+    | Some(issuer) -> sender_check(issuer, store, full_param, "NOT_PERMIT_ISSUER")
+    end
+
+;  const updated_permits : permits =
+    List.fold
+      ( function(const permits: permits; const param: revoke_param) : permits is
+          remove_permit(param.1, param.0, permits)
+      , params
+      , store.permits
+      )
+} with
+    ( (nil : list(operation))
+    , store with record [ permits = updated_permits ]
+    )
+
+(*
+ * Sets the default expiry for the sender (if the param contains a `None`)
+ * or for a specific permit (if the param contains a `Some`).
+ *
+ * When the permit whose expiry should be set does not exist,
+ * nothing happens.
+ *)
+function set_expiry
+  ( const param: set_expiry_param
+  ; const store : storage
+  ) : entrypoint is block
+{ const new_expiry : seconds = param.0
+; const updated_permits : permits =
+    case param.1 of
+    | None ->
+        set_user_default_expiry(Tezos.sender, new_expiry, store.permits)
+    | Some(hash_and_address) ->
+        set_permit_expiry(hash_and_address.1, hash_and_address.0, new_expiry, store.permits)
+    end
+} with
+    ( (nil : list(operation))
+    , store with record [ permits = updated_permits ]
+    )
+
+(*
+ * Retrieves the contract's default permit expiry and leaves the storage untouched.
+ *)
+function get_default_expiry
+  ( const parameter: get_default_expiry_param
+  ; const store : storage
+  ) : entrypoint is block
+{ const transfer_operation : operation =
+    Tezos.transaction (store.default_expiry, 0mutez, parameter.1)
+} with
+    ( list [transfer_operation]
+    , store
+    )
+
+(*
+ * Retrieves the contract's permit counter and leaves the storage untouched.
+ *)
+function get_counter
+  ( const parameter: get_counter_param
+  ; const store : storage
+  ) : entrypoint is block
+{ const transfer_operation : operation =
+    Tezos.transaction (store.permit_counter, 0mutez, parameter.1)
+} with
+    ( list [transfer_operation]
+    , store
+    )

--- a/ligo/stablecoin/fa1.2/core.ligo
+++ b/ligo/stablecoin/fa1.2/core.ligo
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: MIT
+
+#include "actions.ligo"
+
+(*
+ * FA2 entrypoints that are specified in [tzip-12](https://gitlab.com/tzip/tzip/-/blob/827c6c5f9e504e9c4a63e265f86dce24f5c5cef9/proposals/tzip-12/tzip-12.md)
+ *)
+function fa2_main
+  ( const action : parameter
+  ; const store  : storage
+  ; const full_param : closed_parameter
+  ) : entrypoint
+is case action of
+    Transfer                (params) -> transfer                (params, store, full_param)
+  | Balance_of              (params) -> balance_of              (params, store)
+  | Token_metadata_registry (params) -> token_metadata_registry (params, store)
+  | Update_operators        (params) -> update_operators_action (params, store, full_param)
+  | Is_operator             (params) -> is_operator_action      (params, store)
+end
+
+
+(*
+ * Root entrypoint of stablecoin smart-contract
+ *)
+function stablecoin_main
+  ( const full_param : closed_parameter
+  ; const store  : storage
+  ) : entrypoint is block
+{ fail_on (Tezos.amount =/= 0tz, "XTZ_RECEIVED") // Validate whether the contract receives non-zero amount of tokens
+} with case full_param of
+    Call_FA2              (params) -> fa2_main              (params, store, full_param)
+  | Pause                 (params) -> pause                 (params, store, full_param)
+  | Unpause               (params) -> unpause               (params, store, full_param)
+  | Configure_minter      (params) -> configure_minter      (params, store, full_param)
+  | Remove_minter         (params) -> remove_minter         (params, store, full_param)
+  | Mint                  (params) -> mint                  (params, store)
+  | Burn                  (params) -> burn                  (params, store)
+  | Transfer_ownership    (params) -> transfer_ownership    (params, store, full_param)
+  | Accept_ownership      (params) -> accept_ownership      (params, store, full_param)
+  | Change_master_minter  (params) -> change_master_minter  (params, store, full_param)
+  | Change_pauser         (params) -> change_pauser         (params, store, full_param)
+  | Set_transferlist      (params) -> set_transferlist      (params, store, full_param)
+  | Permit                (params) -> add_permit            (params, store)
+  | Revoke                (params) -> revoke_permits        (params, store, full_param)
+  | Set_expiry            (params) -> set_expiry            (params, store)
+  | Get_default_expiry    (params) -> get_default_expiry    (params, store)
+  | Get_counter           (params) -> get_counter           (params, store)
+  end

--- a/ligo/stablecoin/fa1.2/core.ligo
+++ b/ligo/stablecoin/fa1.2/core.ligo
@@ -1,22 +1,26 @@
 // SPDX-FileCopyrightText: 2020 TQ Tezos
 // SPDX-License-Identifier: MIT
 
+#include "spec.ligo"
+#include "../permit.ligo"
+#include "permit.ligo"
+#include "spender_allowances.ligo"
 #include "actions.ligo"
 
 (*
- * FA2 entrypoints that are specified in [tzip-12](https://gitlab.com/tzip/tzip/-/blob/827c6c5f9e504e9c4a63e265f86dce24f5c5cef9/proposals/tzip-12/tzip-12.md)
+ * FA1.2 entrypoints that are specified in [tzip-12](https://gitlab.com/tzip/tzip/-/blob/827c6c5f9e504e9c4a63e265f86dce24f5c5cef9/proposals/tzip-12/tzip-12.md)
  *)
-function fa2_main
+function fa1_2_main
   ( const action : parameter
   ; const store  : storage
   ; const full_param : closed_parameter
   ) : entrypoint
 is case action of
-    Transfer                (params) -> transfer                (params, store, full_param)
-  | Balance_of              (params) -> balance_of              (params, store)
-  | Token_metadata_registry (params) -> token_metadata_registry (params, store)
-  | Update_operators        (params) -> update_operators_action (params, store, full_param)
-  | Is_operator             (params) -> is_operator_action      (params, store)
+  | Transfer       (params) -> transfer         (params, store, full_param)
+  | Approve        (params) -> approve          (params, store, full_param)
+  | GetBalance     (params) -> get_balance      (params, store)
+  | GetAllowance   (params) -> get_allowance    (params, store)
+  | GetTotalSupply (params) -> get_total_supply (params, store)
 end
 
 
@@ -29,7 +33,7 @@ function stablecoin_main
   ) : entrypoint is block
 { fail_on (Tezos.amount =/= 0tz, "XTZ_RECEIVED") // Validate whether the contract receives non-zero amount of tokens
 } with case full_param of
-    Call_FA2              (params) -> fa2_main              (params, store, full_param)
+    Call_FA1_2            (params) -> fa1_2_main            (params, store, full_param)
   | Pause                 (params) -> pause                 (params, store, full_param)
   | Unpause               (params) -> unpause               (params, store, full_param)
   | Configure_minter      (params) -> configure_minter      (params, store, full_param)

--- a/ligo/stablecoin/fa1.2/permit.ligo
+++ b/ligo/stablecoin/fa1.2/permit.ligo
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2020 tqtezos
+// SPDX-License-Identifier: MIT
+
+(*
+ * Permit library for stablecoin smart-contract
+ *)
+
+
+(*
+ * Alternative version of `sender_check` that takes a lambda to run when
+ * 1) the sender is not the expected user
+ * 2) the expected user did not issue a permit.
+ *
+ *)
+function sender_check_
+  ( const expected_user : address
+  ; const store : storage
+  ; const full_param : closed_parameter
+  ; const on_err : unit -> storage
+  ) : storage is
+  if Tezos.sender = expected_user then
+    store
+  else
+    block {
+      const full_param_hash : blake2b_hash = Crypto.blake2b(Bytes.pack(full_param))
+    ; const user_permits : user_permits =
+        case Big_map.find_opt(expected_user, store.permits) of
+          Some(user_permits) -> user_permits
+        | None -> new_user_permits
+        end
+    }
+      with
+        case Map.find_opt(full_param_hash, user_permits.permits) of
+          None ->
+            // The expected user did not call this entrypoint, nor did they issue a permit, so we fail here.
+            on_err(Unit)
+        | Some(permit_info) ->
+            if has_expired(store.default_expiry, user_permits.expiry, permit_info) then
+              (failwith("EXPIRED_PERMIT") : storage)
+            else
+              // A permit exists. Consume it (i.e. delete it from the permits map).
+              store with record [
+                permits = Big_map.update(
+                  expected_user,
+                  Some(
+                    user_permits with record [
+                      permits = Map.remove(full_param_hash, user_permits.permits)
+                    ]
+                  ),
+                  store.permits
+                )
+              ]
+        end

--- a/ligo/stablecoin/fa1.2/spec.ligo
+++ b/ligo/stablecoin/fa1.2/spec.ligo
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: MIT
+
+(*
+ * Stablecoin types that are specified in
+ * https://github.com/tqtezos/stablecoin/blob/317b9346b287a4f2c2606c4929237d87008fdad4/docs/specification.md
+ *)
+
+(* ------------------------------------------------------------- *)
+
+(*
+ * Parameter types
+ *)
+
+type token_id is nat
+
+const default_token_id : token_id = 0n;
+
+(*
+ * This function fails if provided token_id is not equal to
+ * default one, restricting all operations to be one-token
+ * (that are allowed for `default_token_id`)
+ *)
+function validate_token_type
+  ( const token_id : token_id
+  ) : unit is
+    if token_id =/= default_token_id
+    then failwith ("FA2_TOKEN_UNDEFINED")
+    else unit
+
+(*
+ * Same as above but for a list of token ids
+ *)
+function validate_token_types
+  ( const token_ids : list (token_id)
+  ) : unit is List.fold
+    ( function
+        ( const u        : unit
+        ; const token_id : token_id
+        ) : unit is validate_token_type (token_id)
+    , token_ids
+    , unit
+    )
+
+type transfer_destination_ is record
+  to_      : address
+; token_id : token_id
+; amount   : nat
+end
+
+type transfer_destination is michelson_pair_right_comb(transfer_destination_)
+
+type transfer_param_ is record
+  from_ : address
+; txs : list (transfer_destination)
+end
+
+type transfer_param is michelson_pair_right_comb(transfer_param_)
+
+type transfer_params is list (transfer_param)
+
+type balance_of_request is record
+   owner    :  address
+;  token_id : token_id
+end
+
+type balance_of_response_ is record
+  request : balance_of_request
+; balance : nat
+end
+
+type balance_of_response is michelson_pair_right_comb(balance_of_response_)
+
+type balance_of_params_ is record
+  requests : list (balance_of_request)
+; callback : contract (list (balance_of_response))
+end
+
+type balance_of_params is michelson_pair_right_comb(balance_of_params_)
+
+type token_metadata_ is record
+  token_id  : token_id
+; symbol    : string
+; name      : string
+; decimals  : nat
+; extras    : map (string, string)
+end
+
+type token_metadata is michelson_pair_right_comb(token_metadata_)
+
+type token_metadata_registry_params is contract (address)
+
+type operator_param_ is record
+  owner    : address
+; operator : address
+end
+
+type operator_param is michelson_pair_right_comb(operator_param_)
+
+type update_operator_param is
+| Add_operator    of operator_param
+| Remove_operator of operator_param
+
+type update_operator_params is list (update_operator_param)
+
+type is_operator_response_ is record
+  operator    : operator_param
+; is_operator : bool
+end
+
+type is_operator_response is michelson_pair_right_comb(is_operator_response_)
+
+type is_operator_params_ is record
+  operator : operator_param
+; callback : contract (is_operator_response)
+end
+
+type is_operator_params is michelson_pair_right_comb(is_operator_params_)
+
+(* ------------------------------------------------------------- *)
+
+type operator_transfer_policy_ is
+| No_transfer
+| Owner_transfer
+| Owner_or_operator_transfer
+
+type operator_transfer_policy is michelson_or_right_comb(operator_transfer_policy_)
+
+type pause_params is unit
+
+type unpause_params is unit
+
+type configure_minter_params_ is record
+  minter                    : address
+; current_minting_allowance : option (nat)
+; new_minting_allowance     : nat
+end
+
+type configure_minter_params is michelson_pair_right_comb (configure_minter_params_)
+
+type remove_minter_params is address
+
+type mint_param_ is record
+  to_    : address
+; amount : nat
+end
+
+type mint_param is michelson_pair_right_comb (mint_param_)
+
+type mint_params is list (mint_param)
+
+type burn_params is list (nat)
+
+type transfer_ownership_param is address
+
+type accept_ownership_param is unit
+
+type change_master_minter_param is address
+
+type change_pauser_param is address
+
+type parameter is
+  Transfer                of transfer_params
+| Balance_of              of balance_of_params
+| Token_metadata_registry of token_metadata_registry_params
+| Update_operators        of update_operator_params
+| Is_operator             of is_operator_params
+
+(* ------------------------------------------------------------- *)
+
+(*
+ * Hooks
+ *)
+
+// Currently it has the same structure as `transfer_param` but
+// with optional participants
+type transfer_destination_descriptor_ is record
+  to_      : option (address)
+; token_id : token_id
+; amount   : nat
+end
+
+type transfer_destination_descriptor is michelson_pair_right_comb(transfer_destination_descriptor_)
+
+type transfer_descriptor_ is record
+  from_ : option (address)
+; txs   : list (transfer_destination_descriptor)
+end
+
+type transfer_descriptor is michelson_pair_right_comb(transfer_descriptor_)
+
+type transfer_descriptor_param_ is record
+   fa2      : address
+;  batch    : list(transfer_descriptor)
+;  operator : address
+end
+
+type transfer_descriptor_param is michelson_pair_right_comb(transfer_descriptor_param_)
+
+(*
+ * Transferlist
+ *)
+
+type transferlist_transfer_item is michelson_pair(address, "from", list(address), "tos")
+
+type transferlist_assert_transfers_param is list(transferlist_transfer_item)
+
+type transferlist_assert_receiver_param is address
+
+type transferlist_assert_receivers_param is list(address)
+
+type set_transferlist_param is option(address)
+
+type blake2b_hash is bytes
+
+type seconds is nat
+
+type permit_info is
+  record [
+    created_at: timestamp
+  ; expiry: option(seconds)
+  ]
+
+type user_permits is
+  record [
+    permits: map (blake2b_hash, permit_info)
+  ; expiry: option(seconds)
+  ]
+
+type permits is big_map (address, user_permits)
+
+type permit_param is (key * (signature * blake2b_hash))
+
+type revoke_param is blake2b_hash * address
+type revoke_params is list(revoke_param)
+
+type set_expiry_param is (seconds * option(blake2b_hash * address))
+
+type get_default_expiry_param is michelson_pair_right_comb(record
+  param : unit
+; callback : contract(seconds)
+end)
+
+(*
+ * A counter that's incremented everytime a permit is created.
+ *
+ * When creating a new permit, the `permit` entrypoint verifies that the permit has
+ * been signed with the contract's current counter. It then increments the counter by 1.
+ *
+ * This ensures that a permit's signature is valid for one use only.
+ *)
+type counter is nat
+
+type get_counter_param is michelson_pair_right_comb(record
+  param : unit
+; callback : contract(counter)
+end)
+
+(* ------------------------------------------------------------- *)
+
+(* Stablecoin parameter *)
+type closed_parameter is
+| Call_FA2              of parameter
+| Pause                 of pause_params
+| Unpause               of unpause_params
+| Configure_minter      of configure_minter_params
+| Remove_minter         of remove_minter_params
+| Mint                  of mint_params
+| Burn                  of burn_params
+| Transfer_ownership    of transfer_ownership_param
+| Accept_ownership      of accept_ownership_param
+| Change_master_minter  of change_master_minter_param
+| Change_pauser         of change_pauser_param
+| Set_transferlist      of set_transferlist_param
+| Permit                of permit_param
+| Revoke                of revoke_params
+| Set_expiry            of set_expiry_param
+| Get_default_expiry    of get_default_expiry_param
+| Get_counter           of get_counter_param
+
+(* ------------------------------------------------------------- *)
+
+(*
+ * Storage
+ *)
+
+type owner is address
+type operator is address
+
+type operators is
+  big_map ((owner * operator), unit)
+
+type roles is record
+  owner         : address
+; pending_owner : option (address)
+; pauser        : address
+; master_minter : address
+end
+
+type ledger is big_map (address, nat)
+
+type minting_allowances is map (address, nat)
+
+type storage is record
+  ledger                  : ledger
+; token_metadata_registry : address
+; minting_allowances      : minting_allowances
+; paused                  : bool
+; roles                   : roles
+; operators               : operators
+; transferlist_contract   : option(address)
+; permit_counter          : counter
+; permits                 : permits
+; default_expiry          : seconds
+end
+
+type entrypoint is list (operation) * storage

--- a/ligo/stablecoin/fa1.2/spender_allowances.ligo
+++ b/ligo/stablecoin/fa1.2/spender_allowances.ligo
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: MIT
+
+(*
+ * Spender allowances library for FA1.2 contracts
+ *)
+
+function get_allowance
+  ( const owner: address
+  ; const spender: address
+  ; const spender_allowances: spender_allowances
+  ) : nat is
+  case Big_map.find_opt((owner, spender), spender_allowances) of
+  | None -> 0n
+  | Some(allowance) -> allowance
+  end
+
+(*
+ * Unconditionally set a spender's allowance to the given amount.
+ * NOTE: for internal use only.
+ *)
+function set_allowance
+  ( const owner: address
+  ; const spender: address
+  ; const allowance: nat
+  ; const spender_allowances: spender_allowances
+  ): spender_allowances is
+  // Note: this is an optimization. When an allowance is set to `0`, we can
+  // instead remove the entry from the big_map.
+  if allowance = 0n then
+    Big_map.update((owner, spender), (None: option(nat)), spender_allowances)
+  else
+    Big_map.update((owner, spender), Some(allowance), spender_allowances)
+
+
+type deduct_from_allowance_result is
+  | Deducted of spender_allowances
+  | NotEnoughAllowance of
+      ( record
+          required: nat;
+          present: nat
+        end
+      )
+
+(*
+ * If the owner is trying to spend tokens from their own account, no allowances are deducted.
+ * Otherwise, this function tries to deduct the required amount of tokens
+ * from the spender's allowance.
+ * If the spender does not have enough allowance, this function returns `NotEnoughAllowance`.
+ *)
+function deduct_from_allowance
+  ( const owner: address
+  ; const spender: address
+  ; const value: nat
+  ; const spender_allowances: spender_allowances
+  ): deduct_from_allowance_result is
+  if spender = owner then
+    Deducted(spender_allowances)
+  else block {
+    const current_allowance: nat = get_allowance(owner, spender, spender_allowances)
+  } with
+    case is_nat(current_allowance - value) of
+    | None ->
+        NotEnoughAllowance(record [required = value; present = current_allowance])
+    | Some(new_allowance) ->
+        Deducted(set_allowance(owner, spender, new_allowance, spender_allowances))
+    end
+
+(*
+ * Allows `spender` to spend the given amount of tokens from the `owner`'s account.
+ *
+ * If `spender` already had an allowance, it is overriden by the new allowance.
+ *
+ * As per the FA1.2 spec, attempts to change a spender's allowance from a
+ * non-zero to a non-zero value fail with "UnsafeAllowanceChange".
+ *
+ *)
+function approve_allowance
+  ( const owner: address
+  ; const spender: address
+  ; const new_allowance: nat
+  ; const spender_allowances: spender_allowances
+  ) : spender_allowances is block
+{ const current_allowance: nat = get_allowance(owner, spender, spender_allowances)
+
+  // We're using Embedded Michelson here to get around the limitation that,
+  // currently, Ligo's `failwith` only supports strings and numeric types,
+  // but not, for example, pairs.
+  // https://ligolang.org/docs/advanced/embedded-michelson/
+  //
+  // Once this MR is merged, we should be able to use Ligo's `failwith`:
+  // https://gitlab.com/ligolang/ligo/-/issues/193
+; const failwith_ : (string * nat -> spender_allowances) =
+  [%Michelson ({| { FAILWITH } |} : string * nat -> spender_allowances)]
+
+} with
+  if current_allowance =/= 0n and new_allowance =/= 0n then
+    (failwith_(("UnsafeAllowanceChange", current_allowance)) : spender_allowances)
+  else
+    set_allowance(owner, spender, new_allowance, spender_allowances)


### PR DESCRIPTION
## Description

Added a new version of stablecoin that implements FA1.2 instead of FA2.

The purpose of this contract is just to compare gas/transaction costs against the FA2 version.

I added:
* SMT tests to verify the implementation is correct
* Some simple Nettest tests, so we can originate the contract and call each FA1.2 operation once, and check the gas/transaction costs.

## Stats
Here are the numbers I collected. I included links to logs and block explorers, so others can double-check my numbers.

Full nettest log: https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/complete.log

Block explorer: https://better-call.dev/carthagenet/KT1VuoysRj6tWFXAjrbQd67YMnTMi3SpNTdC/operations


* Origination:
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/origination.log)
  - consumed gas: 448089
  - transaction cost: 12.695322 ꜩ
  - op size: 12414 bytes


* approve
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/approve.log)
  - transaction cost: 0.108456
  - gas: 411377
* getAllowance
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/getAllowance.log)
  - transaction cost: 0.044751
  - gas: 411673
* getBalance
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/getBalance.log)
  - transaction cost: 0.044675
  - gas: 411248
* getTotalSupply
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/getTotalSupply.log)
  - transaction cost: 0.044584
  - gas: 410574
* transfer
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/transfer.log)
  - transaction cost: 0.041564
  - gas: 412046
* pre-approved transfer
  - [log](https://gist.githubusercontent.com/dcastro/e50489a46eb54fc69ce1667a3f42127a/raw/050ccf99fabc7b64a003bc1b89c1dad1e96735f2/preApprovedTransfer.log)
  - transaction cost: 0.041747
  - gas: 413869



<!--
Full nettest log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/43d4398e26737f33a38690eeb354dfdce7d4d8e4/complete.log

* Origination
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/origination.log
  - contract address: KT1GrQC4nGZckcfeCtLu2sKphsNsoxUoLNtK
  - contract in block explorer: https://carthagenet.tezblock.io/account/KT1GrQC4nGZckcfeCtLu2sKphsNsoxUoLNtK
  - tx hash: ooiBeUeLRhoMs5jkL13yddh6awRHrHiPxqZLD1ecnN3qh4hQFbb
  - explorer: https://carthagenet.tezblock.io/transaction/ooiBeUeLRhoMs5jkL13yddh6awRHrHiPxqZLD1ecnN3qh4hQFbb
  - "consumed_gas":"448747"
  - "storage_size":"12409"
  - fee: 0.057416 ꜩ

* approve
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/approve.log
  - tx hash: oneUtPM9LXA1P1VxVb7KQyB27WwxpmRXixXRyBd5Kp6WktH8ahW
  - explorer: https://carthagenet.tezblock.io/transaction/oneUtPM9LXA1P1VxVb7KQyB27WwxpmRXixXRyBd5Kp6WktH8ahW
  - fee: 0.041508ꜩ
  - gas: 411872
* getAllowance
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/getAllowance.log
  - tx hash: oojC3ynYo9tLFpk2oFwMGefvyyHrHk1c9hiDQwCMJxsyAwZiz1d
  - explorer: https://carthagenet.tezblock.io/transaction/oojC3ynYo9tLFpk2oFwMGefvyyHrHk1c9hiDQwCMJxsyAwZiz1d
  - fee: 0.042803ꜩ
  - gas: 11829
* getBalance
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/getBalance.log
  - tx hash: opQMt6BEJ77GKaSaea9P31KoANNfzDH11DK9sfR6g5muCWdUwyC
  - explorer: https://carthagenet.tezblock.io/transaction/opQMt6BEJ77GKaSaea9P31KoANNfzDH11DK9sfR6g5muCWdUwyC
  - fee: 0.042727ꜩ
  - gas: 411720
* getTotalSupply
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/getTotalSupply.log
  - tx hash: ooKSiXtnMzWKX8SFR8RpUrU8J6Vatk9UrzTqPh5X5sDVY83EvQM
  - explorer: https://carthagenet.tezblock.io/transaction/ooKSiXtnMzWKX8SFR8RpUrU8J6Vatk9UrzTqPh5X5sDVY83EvQM
  - fee: 0.042636ꜩ
  - gas: 411069
* transfer
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/transfer.log
  - tx hash: ooVHi1gPQZXb4D6nSCexrzdn5GtTpSovEpPVEe91n4VVAT7vodE
  - explorer: https://carthagenet.tezblock.io/transaction/ooVHi1gPQZXb4D6nSCexrzdn5GtTpSovEpPVEe91n4VVAT7vodE
  - fee: 0.041616ꜩ
  - gas: 412518
* pre-approved transfer
  - log: https://gist.githubusercontent.com/dcastro/971d8a35e985cc2f98129317656eb422/raw/448f10dd225b189f897fe1e27674048c3b6a47ee/preApprovedTransfer.log
  - tx hash: opKd9mEdDkUsRwMhvgCEVnwUyWv73GS4WQfvWucsQR7wG2mJMKL
  - explorer: https://carthagenet.tezblock.io/transaction/opKd9mEdDkUsRwMhvgCEVnwUyWv73GS4WQfvWucsQR7wG2mJMKL
  - fee: 0.041799ꜩ
  - gas: 414341


Contract size (unoptimized)
  * stablecoin.tz: 103k
  * stablecoin.fa1.2.tz: 107k

Contract size (optimized)
  * stablecoin.tz: 161k
  * stablecoin.fa1.2.tz: 169k

-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #94

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
