### PR TITLE
[#113] Use valid metadata registry in nettests

### DIFF
--- a/haskell/nettest/FA1_2Comparison.hs
+++ b/haskell/nettest/FA1_2Comparison.hs
@@ -15,7 +15,8 @@ import Util.Named ((.!))
 import Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin as SFA2
 import Lorentz.Contracts.StablecoinFA1_2 as SFA1_2
-import Lorentz.Contracts.Test.Common (registryAddress)
+
+import Lorentz.Contracts.Test.Common (nettestOriginateMetadataRegistry)
 
 -- | This test originates both the FA1.2 and FA2 versions of stablecoin,
 -- and performs a single @transfer@ operation.
@@ -67,6 +68,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
   comment "Calling transfer"
   callFrom (AddressResolved owner1) fa1_2ContractAddr (Call @"Transfer") (#from .! owner1, #to .! owner2, #value .! 2)
 
+  mrAddress <- nettestOriginateMetadataRegistry
   let fa2Storage = SFA2.Storage
         { sDefaultExpiry = 1000
         , sLedger = BigMap balances
@@ -77,7 +79,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
         , sRoles = roles
         , sTransferlistContract = Nothing
         , sOperators = mempty
-        , sTokenMetadataRegistry = registryAddress
+        , sTokenMetadataRegistry = mrAddress
         }
 
   comment "Originating Stablecoin FA2 contract"

--- a/haskell/nettest/Main.hs
+++ b/haskell/nettest/Main.hs
@@ -63,7 +63,6 @@ main = do
     scenarioWithInternalTransferlist impl = do
       niComment impl "Stablecoin contract nettest scenarioWithInternalTransferlist"
       scNettestScenario
-        mkInitialStorage
         originateTransferlistInternal
         Internal
         impl
@@ -72,7 +71,6 @@ main = do
     scenarioWithExternalTransferlist impl = do
       niComment impl "Stablecoin contract nettest scenarioWithExternalTransferlist"
       scNettestScenario
-        mkInitialStorage
         (originateTransferlistExternal @m @capsM)
         External
         impl

--- a/haskell/nettest/Permit.hs
+++ b/haskell/nettest/Permit.hs
@@ -23,7 +23,8 @@ import Lorentz.Contracts.Stablecoin
   stablecoinContract)
 
 import Lorentz.Contracts.Test.Common
-  (OriginationParams(..), addAccount, defaultOriginationParams, mkInitialStorage)
+  (OriginationParams(..), addAccount, defaultOriginationParams, mkInitialStorage,
+  nettestOriginateMetadataRegistry)
 
 
 permitScenario :: NettestScenario m
@@ -39,13 +40,15 @@ permitScenario = uncapsNettest $ do
   (_, user1) <- createUser "Steve"
 
   comment "Originating contracts"
-  let storage = mkInitialStorage $
+  mrAddress <- nettestOriginateMetadataRegistry
+  let originationParams =
         addAccount (owner1 , ([], 1000)) $
           defaultOriginationParams
             { opOwner = owner1
             , opPauser = pauser
             , opMasterMinter = masterMinter
             }
+      storage = mkInitialStorage originationParams mrAddress
   contract <- TAddress @Parameter <$> originateUntypedSimple
     "nettest.Stablecoin"
     (untypeValue (toVal storage))

--- a/haskell/src/Lorentz/Contracts/Stablecoin.hs
+++ b/haskell/src/Lorentz/Contracts/Stablecoin.hs
@@ -12,6 +12,7 @@ module Lorentz.Contracts.Stablecoin
   , MetadataRegistryStorage
   , MetadataRegistryStorageView
   , mkMetadataRegistryStorage
+  , defaultMetadataRegistryStorage
   , MintParams
   , MintParam(..)
   , BurnParams
@@ -34,7 +35,6 @@ module Lorentz.Contracts.Stablecoin
   , SetExpiryParam(..)
   , GetDefaultExpiryParam
   , minterLimit
-  , stablecoinTokenMetadata
 
   -- Embedded LIGO contracts
   , stablecoinContract
@@ -42,18 +42,19 @@ module Lorentz.Contracts.Stablecoin
   ) where
 
 import Data.FileEmbed (embedStringFile)
+import qualified Data.Map as Map
 import Fmt
 import qualified Text.Show
 
 import Lorentz
 import qualified Lorentz as L
 import Michelson.Test.Import (readContract)
+import qualified Michelson.Typed as T
 import Morley.Client (BigMapId(..))
 import qualified Tezos.Crypto as Hash
 
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.StablecoinPath (metadataRegistryContractPath, stablecoinPath)
-import qualified Michelson.Typed as T
 
 ------------------------------------------------------------------
 -- Parameter
@@ -316,16 +317,6 @@ type StorageView = Storage' BigMapId
 deriving stock instance Show StorageView
 deriving anyclass instance IsoValue StorageView
 
--- We will hard code stablecoin token metadata here
-stablecoinTokenMetadata :: FA2.TokenMetadata
-stablecoinTokenMetadata = FA2.TokenMetadata
-  { tmTokenId = 0
-  , tmSymbol = [mt|TEST|]
-  , tmName = [mt|Test|]
-  , tmDecimals = 8
-  , tmExtras = mempty
-  }
-
 -- Currently the contract allows to add upto 12 minters.
 minterLimit :: Int
 minterLimit = 12
@@ -345,8 +336,30 @@ deriving stock instance Show (MetadataRegistryStorageView)
 deriving anyclass instance IsoValue (MetadataRegistryStorage)
 deriving anyclass instance IsoValue (MetadataRegistryStorageView)
 
-mkMetadataRegistryStorage :: big_map FA2.TokenId FA2.TokenMetadata -> MetadataRegistryStorage' big_map
-mkMetadataRegistryStorage bm = MetadataRegistryStorage () bm
+-- | Construct the storage for the Metadata Registry contract.
+mkMetadataRegistryStorage :: MText -> MText -> Natural -> MetadataRegistryStorage
+mkMetadataRegistryStorage symbol name decimals =
+  MetadataRegistryStorage
+    { mrsDummyField = ()
+    , mrsTokenMetadata = BigMap $ Map.singleton 0 $
+        FA2.TokenMetadata
+          { tmTokenId = 0
+          , tmSymbol = symbol
+          , tmName = name
+          , tmDecimals = decimals
+          , tmExtras = mempty
+          }
+    }
+
+-- | The default storage for the Metadata Registry storage
+-- with some hardcoded token metadata.
+-- Useful for testing.
+defaultMetadataRegistryStorage :: MetadataRegistryStorage
+defaultMetadataRegistryStorage =
+  mkMetadataRegistryStorage
+    [mt|TEST|]
+    [mt|Test|]
+    8
 
 -- This empty splice lets us workaround the GHC stage restriction, and refer to `Storage`
 -- in the TH splices below.

--- a/haskell/src/Stablecoin/Client/Contract.hs
+++ b/haskell/src/Stablecoin/Client/Contract.hs
@@ -3,19 +3,14 @@
 
 module Stablecoin.Client.Contract
   ( mkInitialStorage
-  , mkRegistryStorage
   , InitialStorageData(..)
   ) where
 
-import qualified Data.Map.Strict as Map
 import Michelson.Text (MText)
-import Michelson.Typed (BigMap(BigMap))
 import Morley.Client (AddressOrAlias)
 import Tezos.Address (Address)
 
-import Lorentz.Contracts.Spec.FA2Interface (TokenMetadata(..))
-import Lorentz.Contracts.Stablecoin
-  (Expiry, MetadataRegistryStorage, Roles(..), Storage, Storage'(..), mkMetadataRegistryStorage)
+import Lorentz.Contracts.Stablecoin (Expiry, Roles(..), Storage, Storage'(..))
 
 type family ComputeRegistryAddressType a where
   ComputeRegistryAddressType Address = Address
@@ -53,15 +48,4 @@ mkInitialStorage (InitialStorageData {..}) =
         }
     , sTokenMetadataRegistry = isdTokenMetadataRegistry
     , sTransferlistContract = isdTransferlist
-    }
-
--- | Constuct the stablecoin metadata
-mkRegistryStorage :: MText -> MText -> Natural -> MetadataRegistryStorage
-mkRegistryStorage symbol name decimals = mkMetadataRegistryStorage $ BigMap $ Map.singleton 0 $
-  TokenMetadata
-    { tmTokenId = 0
-    , tmSymbol = symbol
-    , tmName = name
-    , tmDecimals = decimals
-    , tmExtras = mempty
     }

--- a/haskell/src/Stablecoin/Client/Impl.hs
+++ b/haskell/src/Stablecoin/Client/Impl.hs
@@ -41,11 +41,9 @@ import qualified Data.Map as M
 import Fmt (Buildable(build), pretty, (+|), (|+))
 import Lorentz (EntrypointRef(Call), HasEntrypointArg, arg, useHasEntrypointArg)
 import Michelson.Typed (Dict(..), IsoValue, fromVal, toVal)
-import qualified Michelson.Typed as T
 import Morley.Client
   (AddressOrAlias(..), Alias, MorleyClientM, TezosClientError(UnknownAddress), getAlias,
-  getContractScript, lTransfer, originateContract, originateUntypedContract, readBigMapValue,
-  readBigMapValueMaybe)
+  getContractScript, lTransfer, originateContract, readBigMapValue, readBigMapValueMaybe)
 import qualified Morley.Client as Client
 import Morley.Client.RPC (OriginationScript(OriginationScript))
 import Morley.Client.TezosClient (resolveAddress)
@@ -91,14 +89,13 @@ deploy (arg #sender -> sender) alias initialStorageData = do
             (isdTokenSymbol initialStorageData)
             (isdTokenName initialStorageData)
             (isdTokenDecimals initialStorageData)
-          registryStorageVal = toVal registryStorage
-      snd <$> originateUntypedContract
+      snd <$> originateContract
         False
         "stablecoin-metadata"
         sender
         (unsafeMkMutez 0)
         registryContract
-        (T.untypeValue registryStorageVal)
+        (toVal registryStorage)
 
   let initialStorageData' = initialStorageData
         { isdMasterMinter = masterMinter

--- a/haskell/src/Stablecoin/Client/Impl.hs
+++ b/haskell/src/Stablecoin/Client/Impl.hs
@@ -55,9 +55,9 @@ import Util.Named ((:!), (.!))
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin
   (ConfigureMinterParam(..), MetadataRegistryStorage, MetadataRegistryStorageView, MintParam(..),
-  Parameter, Roles(..), Storage'(..), StorageView, mrsTokenMetadata, registryContract,
-  stablecoinContract)
-import Stablecoin.Client.Contract (InitialStorageData(..), mkInitialStorage, mkRegistryStorage)
+  Parameter, Roles(..), Storage'(..), StorageView, mkMetadataRegistryStorage, mrsTokenMetadata,
+  registryContract, stablecoinContract)
+import Stablecoin.Client.Contract (InitialStorageData(..), mkInitialStorage)
 
 -- | An address and an optional alias, if one is found.
 data AddressAndAlias = AddressAndAlias Address (Maybe Alias)
@@ -85,7 +85,7 @@ deploy (arg #sender -> sender) alias initialStorageData = do
   metadataRegistry <- case isdTokenMetadataRegistry initialStorageData of
     Just mdr -> resolveAddress mdr
     Nothing -> do
-      let registryStorage :: MetadataRegistryStorage = mkRegistryStorage
+      let registryStorage :: MetadataRegistryStorage = mkMetadataRegistryStorage
             (isdTokenSymbol initialStorageData)
             (isdTokenName initialStorageData)
             (isdTokenDecimals initialStorageData)

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -42,8 +42,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley-ledgers.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    47a94df200451d78d81cf0515f9328645a03bd22 # master
-  # nix-sha256: 0cx2an4kdgg9awd0y008afa6abihsy6rqldq2xxmyb2m20vdzgms
+    cd02068501e57c5893a6642e5100cba66e4b3ae1 # master
   subdirs:
     - code/morley-ledgers
     - code/morley-ledgers-test

--- a/haskell/stack.yaml.lock
+++ b/haskell/stack.yaml.lock
@@ -165,11 +165,11 @@ packages:
     pantry-tree:
       size: 1421
       sha256: 4cb0661fe0a19b6c0d1c8c2eb8aa1a1127a3062312270ac9bdb9c97620e02c38
-    commit: 47a94df200451d78d81cf0515f9328645a03bd22
+    commit: cd02068501e57c5893a6642e5100cba66e4b3ae1
   original:
     subdir: code/morley-ledgers
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: 47a94df200451d78d81cf0515f9328645a03bd22
+    commit: cd02068501e57c5893a6642e5100cba66e4b3ae1
 - completed:
     subdir: code/morley-ledgers-test
     name: morley-ledgers-test
@@ -178,11 +178,11 @@ packages:
     pantry-tree:
       size: 1751
       sha256: 3fd9977d9bc1f41e46fe5c55e7909b66003f124b031c3dafc532a44803981338
-    commit: 47a94df200451d78d81cf0515f9328645a03bd22
+    commit: cd02068501e57c5893a6642e5100cba66e4b3ae1
   original:
     subdir: code/morley-ledgers-test
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: 47a94df200451d78d81cf0515f9328645a03bd22
+    commit: cd02068501e57c5893a6642e5100cba66e4b3ae1
 snapshots:
 - completed:
     size: 531707

--- a/haskell/test/Stablecoin.hs
+++ b/haskell/test/Stablecoin.hs
@@ -24,8 +24,13 @@ import SMT
 import Tezos.Core
 
 origination :: OriginationFn SC.Parameter
-origination (mkInitialStorage -> storageVal) = TAddress @SC.Parameter <$>
-    tOriginate stablecoinContract "Stablecoin contract" (toVal storageVal) (unsafeMkMutez 0)
+origination originationParams = do
+  mrAddress <- originateMetadataRegistry
+  TAddress @SC.Parameter <$> tOriginate
+    stablecoinContract
+    "Stablecoin contract"
+    (toVal (mkInitialStorage originationParams mrAddress))
+    (toMutez 0)
 
 spec_FA2 :: Spec
 spec_FA2 =


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem: the tests use a dummy `tz2` address as the address of the
metadata registry contract. However, the FA2 spec requires that this
address be of a smart contract (i.e., a `KT1` address).

Solution: originate a valid metadata registry contract, and then put its
address in the stablecoin contract's storage.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #113

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
