### PR TITLE
Add nettest run on 007 protocol local-chain

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,7 @@ steps:
      - cd haskell
      - nix build -L -f .. test
      - ./result/bin/stablecoin-test
- - label: nettest-local-chain
+ - label: nettest-local-chain-006
    if: *not_scheduled
    env:
      NETTEST_NODE_ADDR: "localhost"
@@ -59,6 +59,14 @@ steps:
    retry: &retry-nettest
       automatic:
         limit: 1
+ - label: nettest-local-chain-007
+   if: *not_scheduled
+   env:
+     NETTEST_NODE_ADDR: "localhost"
+     NETTEST_NODE_PORT: "8735"
+     MONEYBAG: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
+   commands: *run-nettest
+   retry: *retry-nettest
  - label: nettest-scheduled-carthagenet
    if: build.source == "schedule"
    # use another agent for long scheduled jobs


### PR DESCRIPTION
## Description
Problem: We should test our code on the new 007 protocol.
We already have nettest runs on delphinet,
but they're quite long and thus run only on schedule.

Solution: Now we have a second local-chain that runs 007
protocol. Run nettest scenario on it as well.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TM-457

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
