### PR TITLE
CI: add 'wait' step after uploading generated contract

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,9 @@ steps:
      - stablecoin.fa1.2.tz
      - metadata.tz
 
+ # wait for the contract step to complete, so the next steps can download generated contract
+ - wait
+
  - label: build library
    if: *not_scheduled
    commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,16 +12,20 @@ steps:
      build.source != "schedule"
    command:
      nix run -f. pkgs.hlint -c ./scripts/lint.sh
- - command: nix run -f. pkgs.reuse -c reuse lint
+
+ - label: reuse lint
+   command: nix run -f. pkgs.reuse -c reuse lint
    if: *not_scheduled
-   label: reuse lint
- - command: .buildkite/check-trailing-whitespace.sh
+
+ - label: check trailing whitespace
+   command: .buildkite/check-trailing-whitespace.sh
    if: *not_scheduled
-   label: check trailing whitespace
- - command: "nix run -f https://github.com/serokell/xrefcheck/archive/b54c38d91bd45e5c402ebf51d68c653faf959c2c.tar.gz -c xrefcheck"
+
+ - label: xrefcheck
+   command: "nix run -f https://github.com/serokell/xrefcheck/archive/b54c38d91bd45e5c402ebf51d68c653faf959c2c.tar.gz -c xrefcheck"
    if: *not_scheduled
-   label: xrefcheck
    soft_fail: true
+
  - label: LIGO-contract
    commands:
      - nix-build -A tezos-contract -o stablecoin_raw.tz
@@ -33,11 +37,13 @@ steps:
      - stablecoin.tz
      - stablecoin.fa1.2.tz
      - metadata.tz
+
  - label: build library
    if: *not_scheduled
    commands:
      - eval "$FETCH_CONTRACT"
      - nix build -L -f. lib
+
  - label: test
    if: *not_scheduled
    commands:
@@ -45,6 +51,7 @@ steps:
      - cd haskell
      - nix build -L -f .. test
      - ./result/bin/stablecoin-test
+
  - label: nettest-local-chain-006
    if: *not_scheduled
    env:
@@ -59,6 +66,7 @@ steps:
    retry: &retry-nettest
       automatic:
         limit: 1
+
  - label: nettest-local-chain-007
    if: *not_scheduled
    env:
@@ -67,6 +75,7 @@ steps:
      MONEYBAG: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
    commands: *run-nettest
    retry: *retry-nettest
+
  - label: nettest-scheduled-carthagenet
    if: build.source == "schedule"
    # use another agent for long scheduled jobs
@@ -80,6 +89,7 @@ steps:
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
    timeout_in_minutes: 150
+
  - label: nettest-scheduled-delphinet
    if: build.source == "schedule"
    env:
@@ -89,6 +99,7 @@ steps:
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
    timeout_in_minutes: 150
+
  - label: weeder
    if: *not_scheduled
    commands:
@@ -98,6 +109,7 @@ steps:
      # weeder needs .cabal file:
      - nix run -f.. pkgs.haskellPackages.hpack -c hpack
      - ./result
+
  - label: packaging
    if: *not_scheduled
    commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,6 +95,8 @@ steps:
 
  - label: nettest-scheduled-delphinet
    if: build.source == "schedule"
+   agents:
+    queue: "scheduled"
    env:
      NETTEST_NODE_ADDR: "delphi.testnet.tezos.serokell.team"
      NETTEST_NODE_PORT: "8732"


### PR DESCRIPTION
## Description

Problem: 'LIGO-contract' step uploads an artifact used by the next
steps, so the next steps must not start until it has finished. It wasn't
a problem when we were using a single non-concurrent agent, but when we
added an agent for scheduled pipelines in #119, the job would fail because it
runs concurrently.

Solution: add 'wait' step to avoid running steps which use the contract
until the step which generates the contract has finished
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/OPS-1066

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
