### PR TITLE
Restore retries for scheduled runs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,6 +91,7 @@ steps:
      # more tz, its address: tz1ij8gUYbMRUXa4xX3mNvKguhaWG9GGbURn
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
+   retry: *retry-nettest
    timeout_in_minutes: 150
 
  - label: nettest-scheduled-delphinet
@@ -103,6 +104,7 @@ steps:
      # same address as in carthagenet
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
+   retry: *retry-nettest
    timeout_in_minutes: 150
 
  - label: weeder

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,7 +92,7 @@ steps:
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
    retry: *retry-nettest
-   timeout_in_minutes: 150
+   timeout_in_minutes: 180
 
  - label: nettest-scheduled-delphinet
    if: build.source == "schedule"
@@ -105,7 +105,7 @@ steps:
      MONEYBAG: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
    commands: *run-nettest
    retry: *retry-nettest
-   timeout_in_minutes: 150
+   timeout_in_minutes: 180
 
  - label: weeder
    if: *not_scheduled


### PR DESCRIPTION
## Description

Problem: we used to retry failed scheduled nettest runs on CI
beucase they are fragile, but we stopped doing that at some point
because they could stall CI completely.
Now our scheduled nettests are launched on a separate agent, so
it shouldn't be a problem to restart them once in case of failure.

Solution: add `retry` to two jobs running scheduled nettests.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
