### PR TITLE
[#138] Configure contract-metadata storage.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@
 
 env:
   FETCH_CONTRACT:
-    "mkdir -p haskell/test/resources/ && buildkite-agent artifact download stablecoin.tz haskell/test/resources/ && buildkite-agent artifact download stablecoin.fa1.2.tz haskell/test/resources/ && buildkite-agent artifact download metadata.tz haskell/test/resources/ --step \"LIGO-contract\""
+    "mkdir -p haskell/test/resources/ && buildkite-agent artifact download stablecoin.tz haskell/test/resources/ && buildkite-agent artifact download stablecoin.fa1.2.tz haskell/test/resources/ && buildkite-agent artifact download metadata.tz haskell/test/resources/ && buildkite-agent artifact download tzip16-metadata.tz haskell/test/resources/ --step \"LIGO-contract\""
   TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
 
 steps:
@@ -33,10 +33,12 @@ steps:
      - nix-build -A tezos-contract-fa1-2 -o stablecoin.fa1.2_raw.tz
      - nix run -f. morley -c morley optimize --contract stablecoin.fa1.2_raw.tz --output stablecoin.fa1.2.tz
      - nix-build -A tezos-metadata-contract -o metadata.tz
+     - nix-build -A tezos-tzip16-metadata-contract -o tzip16-metadata.tz
    artifact_paths:
      - stablecoin.tz
      - stablecoin.fa1.2.tz
      - metadata.tz
+     - tzip16-metadata.tz
 
  # wait for the contract step to complete, so the next steps can download generated contract
  - wait

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ TAGS
 /haskell/test/resources/stablecoin.tz
 /haskell/test/resources/stablecoin.fa1.2.tz
 /haskell/test/resources/metadata.tz
+/haskell/test/resources/tzip16-metadata.tz

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,12 @@ README when a new version is released. -->
 * [#144](https://github.com/tqtezos/stablecoin/pull/144)
   * Add `total_supply` field to the contract.
 
+* [142](https://github.com/tqtezos/stablecoin/pull/142)
+  * Deploy TZIP-16 metadata to an external contract by default.
+  * Provide deploy options `--contract-metadata-in-place` and
+    `--contract-metadata-off-chain` to let user to embed the metadata
+    in contract or to use a custom metadata offline uri respectievely.
+
 ## 1.4.0
 
 * [#134](https://github.com/tqtezos/stablecoin/pull/134)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build-ligo:
 	$(MAKE_LIGO) stablecoin.tz
 	$(MAKE_LIGO) stablecoin.fa1.2.tz
 	$(MAKE_LIGO) metadata.tz
+	$(MAKE_LIGO) tzip16-metadata.tz
 
 # Compile LIGO contract and then build everything haskell-related (including tests and benchmarks)
 # with development options.

--- a/default.nix
+++ b/default.nix
@@ -65,6 +65,13 @@ let
     buildPhase = "make metadata.tz";
     installPhase = "cp metadata.tz $out";
   };
+  tezos-tzip16-metadata-contract = pkgs.stdenv.mkDerivation {
+    name = "stablecoin.tz";
+    src = ./ligo;
+    nativeBuildInputs = [ ligo ];
+    buildPhase = "make tzip16-metadata.tz";
+    installPhase = "cp tzip16-metadata.tz $out";
+  };
   tezos-client = (import "${sources.tezos-packaging}/nix/build/pkgs.nix" {}).ocamlPackages.tezos-client;
 
   # nixpkgs has weeder 2, but we use weeder 1
@@ -111,5 +118,5 @@ in
   test = project.stablecoin.components.tests.stablecoin-test;
   nettest = project.stablecoin.components.tests.stablecoin-nettest;
   stablecoin-client = project.stablecoin.components.exes.stablecoin-client;
-  inherit tezos-contract tezos-contract-fa1-2 tezos-metadata-contract tezos-client pkgs weeder-script morley;
+  inherit tezos-contract tezos-contract-fa1-2 tezos-metadata-contract tezos-tzip16-metadata-contract tezos-client pkgs weeder-script morley;
 }

--- a/haskell/Makefile
+++ b/haskell/Makefile
@@ -30,10 +30,12 @@ define build_stablecoin_contract
 	$(MAKE_LIGO) stablecoin.tz
 	$(MAKE_LIGO) stablecoin.fa1.2.tz
 	$(MAKE_LIGO) metadata.tz
+	$(MAKE_LIGO) tzip16-metadata.tz
 	mkdir -p test/resources
 	$(MORLEY) optimize --contract "$(LIGO_DIR)/stablecoin.tz" --output "test/resources/stablecoin.tz"
 	$(MORLEY) optimize --contract "$(LIGO_DIR)/stablecoin.fa1.2.tz" --output "test/resources/stablecoin.fa1.2.tz"
 	cp "$(LIGO_DIR)/metadata.tz" "test/resources/metadata.tz"
+	cp "$(LIGO_DIR)/tzip16-metadata.tz" "test/resources/tzip16-metadata.tz"
 endef
 
 # Build everything haskell-related (including tests and benchmarks) with development options.
@@ -83,3 +85,4 @@ clean:
 	rm -f stablecoin.tz
 	rm -f stablecoin.fa1.2.tz
 	rm -f metadata.tz
+	rm -f tzip16-metadata.tz

--- a/haskell/nettest/FA1_2Comparison.hs
+++ b/haskell/nettest/FA1_2Comparison.hs
@@ -16,7 +16,7 @@ import Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin as SFA2
 import Lorentz.Contracts.StablecoinFA1_2 as SFA1_2
 
-import Lorentz.Contracts.Test.Common (nettestOriginateMetadataRegistry)
+import Lorentz.Contracts.Test.Common (nettestOriginateContractMetadataContract, nettestOriginateMetadataRegistry)
 
 -- | This test originates both the FA1.2 and FA2 versions of stablecoin,
 -- and performs a single @transfer@ operation.
@@ -49,6 +49,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
         , rPendingOwner = Nothing
         }
 
+  cmrFA1_2Address <- nettestOriginateContractMetadataContract SFA2.metadataJSON
   let fa1_2Storage = SFA1_2.Storage
         { sDefaultExpiry = 1000
         , sLedger = BigMap balances
@@ -60,7 +61,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
         , sTransferlistContract = Nothing
         , sTotalSupply = sum balances
         , sSpenderAllowances = mempty
-        , sMetadata = SFA1_2.metadataMap
+        , sMetadata = metadataMap @(()) (RemoteContract cmrFA1_2Address)
         }
 
   fa1_2ContractAddr <- TAddress @SFA1_2.Parameter <$>
@@ -70,6 +71,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
   callFrom (AddressResolved owner1) fa1_2ContractAddr (Call @"Transfer") (#from .! owner1, #to .! owner2, #value .! 2)
 
   mrAddress <- nettestOriginateMetadataRegistry
+  cmrAddress <- nettestOriginateContractMetadataContract SFA2.metadataJSON
   let fa2Storage = SFA2.Storage
         { sDefaultExpiry = 1000
         , sLedger = BigMap balances
@@ -81,7 +83,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
         , sTransferlistContract = Nothing
         , sOperators = mempty
         , sTokenMetadataRegistry = mrAddress
-        , sMetadata = SFA2.metadataMap
+        , sMetadata = SFA2.metadataMap @(()) (RemoteContract cmrAddress)
         , sTotalSupply = 0
         }
 

--- a/haskell/nettest/Nettest.hs
+++ b/haskell/nettest/Nettest.hs
@@ -67,11 +67,14 @@ scNettestScenario originateTransferlist transferlistType = uncapsNettest $ do
   comment "Originating metadata registry contract"
   mrAddress <- nettestOriginateMetadataRegistry
 
+  comment "Originating contract metadata contract"
+  cmrAddress <- nettestOriginateContractMetadataContract metadataJSON
+
   comment "Originating stablecoin contract"
   scAddress <-
     originateUntypedSimple
       "nettest.Stablecoin"
-      (untypeValue (toVal (mkInitialStorage originationParams mrAddress)))
+      (untypeValue (toVal (mkInitialStorage originationParams mrAddress (Just cmrAddress))))
       (T.convertContract stablecoinContract)
 
   comment "Originating transferlist contract"
@@ -365,7 +368,7 @@ scNettestScenario originateTransferlist transferlistType = uncapsNettest $ do
 
       -- We originate a new contract to make sure the minters list is empty
       scAddress' <- do
-        let str = mkInitialStorage (originationParams { opMinters = mempty }) mrAddress
+        let str = mkInitialStorage (originationParams { opMinters = mempty }) mrAddress (Just cmrAddress)
         originateUntypedSimple "nettest.Stablecoin_for_minter_test" (untypeValue $ toVal str) (T.convertContract stablecoinContract)
 
       let

--- a/haskell/nettest/Permit.hs
+++ b/haskell/nettest/Permit.hs
@@ -12,11 +12,12 @@ import Morley.Nettest
 import Lorentz.Contracts.Spec.FA2Interface (TransferDestination(..), TransferParam(..))
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.Stablecoin
-  (ConfigureMinterParam(..), Parameter(..), PermitParam(..), mkPermitHash, stablecoinContract)
+  (ConfigureMinterParam(..), Parameter(..), PermitParam(..), metadataJSON, mkPermitHash,
+  stablecoinContract)
 
 import Lorentz.Contracts.Test.Common
   (OriginationParams(..), addAccount, defaultOriginationParams, mkInitialStorage,
-  nettestOriginateMetadataRegistry)
+  nettestOriginateContractMetadataContract, nettestOriginateMetadataRegistry)
 
 permitScenario :: NettestScenario m
 permitScenario = uncapsNettest $ do
@@ -32,6 +33,7 @@ permitScenario = uncapsNettest $ do
 
   comment "Originating contracts"
   mrAddress <- nettestOriginateMetadataRegistry
+  cmrAddress <- nettestOriginateContractMetadataContract metadataJSON
   let originationParams =
         addAccount (owner1 , ([], 1000)) $
           defaultOriginationParams
@@ -39,7 +41,7 @@ permitScenario = uncapsNettest $ do
             , opPauser = pauser
             , opMasterMinter = masterMinter
             }
-      storage = mkInitialStorage originationParams mrAddress
+      storage = mkInitialStorage originationParams mrAddress (Just cmrAddress)
   contract <- TAddress @Parameter <$> originateUntypedSimple
     "nettest.Stablecoin"
     (untypeValue (toVal storage))

--- a/haskell/nettest/StablecoinClientTest.hs
+++ b/haskell/nettest/StablecoinClientTest.hs
@@ -21,6 +21,7 @@ import Stablecoin.Client.Cleveland
   mint, pause, removeMinter, revealKeyUnlessRevealed, setTransferlist, transferOwnership, unpause,
   updateOperators)
 import qualified Stablecoin.Client.Cleveland as SC
+import Stablecoin.Client.Parser (ContractMetadataOptions(..))
 
 -- | Check that all the `stablecoin-client` commands work.
 stablecoinClientScenario :: StablecoinScenario m ()
@@ -46,6 +47,7 @@ stablecoinClientScenario = do
     , isdTokenDecimals = 3
     , isdTokenMetadataRegistry = Just mdRegisty
     , isdDefaultExpiry = 1000
+    , isdContractMetadataStorage = OpRemoteContract
     }
   let contract = #contract .! AddressResolved contractAddr
 

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -11,6 +11,7 @@ extra-source-files:
 - ChangeLog.md
 - test/resources/stablecoin.tz
 - test/resources/metadata.tz
+- test/resources/tzip16-metadata.tz
 
 synopsis:            FA2-based tezos stablecoin smart contract
 category:            Blockchain
@@ -89,11 +90,12 @@ tests:
       - nettest
 
     dependencies:
+      - aeson
+      - cleveland
       - containers
       - lorentz
       - morley
       - morley-client
-      - cleveland
       - morley-prelude
       - optparse-applicative
       - stablecoin

--- a/haskell/src/Lorentz/Contracts/StablecoinFA1_2.hs
+++ b/haskell/src/Lorentz/Contracts/StablecoinFA1_2.hs
@@ -9,14 +9,10 @@ module Lorentz.Contracts.StablecoinFA1_2
   , stablecoinFA1_2Contract
 
   -- * TZIP-16
-  , metadataMap
   , metadataJSON
   ) where
 
-import qualified Data.Aeson as J
-import qualified Data.ByteString.Lazy as BSL
 import Data.FileEmbed (embedStringFile)
-import qualified Data.Map as Map
 import Fmt (pretty)
 
 import Lorentz as L
@@ -102,12 +98,6 @@ stablecoinFA1_2Contract =
             $(embedStringFile stablecoinFA1_2Path)
       |]
     )
-
-metadataMap :: MetadataMap BigMap
-metadataMap = BigMap $ Map.fromList
-  [ (mempty, encodeUtf8 @Text "tezos-storage:metadataJSON")
-  , ([mt|metadataJSON|], BSL.toStrict (J.encode metadataJSON))
-  ]
 
 metadataJSON :: Metadata (ToT Storage)
 metadataJSON =

--- a/haskell/src/Lorentz/Contracts/StablecoinPath.hs
+++ b/haskell/src/Lorentz/Contracts/StablecoinPath.hs
@@ -6,9 +6,10 @@
 -- Due to GHC stage restriction, they have to be in their own module in order
 -- to be used inside TemplateHaskell splices.
 module Lorentz.Contracts.StablecoinPath
-  ( stablecoinPath
-  , stablecoinFA1_2Path
+  ( contractMetadataRegistryContractPath
   , metadataRegistryContractPath
+  , stablecoinFA1_2Path
+  , stablecoinPath
   ) where
 
 -- | The path to the compiled stablecoin contract.
@@ -22,3 +23,7 @@ stablecoinFA1_2Path = "./test/resources/stablecoin.fa1.2.tz"
 -- | The path to the compiled metadata registry.
 metadataRegistryContractPath :: FilePath
 metadataRegistryContractPath = "./test/resources/metadata.tz"
+
+-- | The path to the compiled contract metadata registry.
+contractMetadataRegistryContractPath :: FilePath
+contractMetadataRegistryContractPath = "./test/resources/tzip16-metadata.tz"

--- a/haskell/src/Stablecoin/Client/Main.hs
+++ b/haskell/src/Stablecoin/Client/Main.hs
@@ -49,7 +49,7 @@ mainProgram (ClientArgs _ globalOptions cmd) = do
       -- prefix option was passed in via the CLI.
       aliasAlreadyExists <- checkIfAliasExists (coerce contractAlias)
 
-      (opHash, contractAddr, metadataRegAddr) <- deploy user (coerce contractAlias) InitialStorageData
+      (opHash, contractAddr, metadataRegAddr, mCMetadataAddr) <- deploy user (coerce contractAlias) InitialStorageData
         { isdMasterMinter = dcoMasterMinter
         , isdContractOwner = dcoContractOwner
         , isdPauser = dcoPauser
@@ -59,12 +59,15 @@ mainProgram (ClientArgs _ globalOptions cmd) = do
         , isdTokenDecimals = dcoTokenDecimals
         , isdTokenMetadataRegistry = dcoTokenMetadataRegistry
         , isdDefaultExpiry = dcoDefaultExpiry
+        , isdContractMetadataStorage = dcoContractMetadata
         }
 
       putTextLn "Contract was successfully deployed."
       putTextLn $ "Operation hash: " <> pretty opHash
       putTextLn $ "Contract address: " <> pretty contractAddr
       putTextLn $ "Metadata registry contract address: " <> pretty metadataRegAddr
+      whenJust mCMetadataAddr $ \addr ->
+        putTextLn $ "Contract metadata contract address: " <> pretty addr
 
       let printAlias = putTextLn $ "Created alias '" <> pretty contractAlias <> "'."
 

--- a/haskell/test/Lorentz/Contracts/Test/FA1_2.hs
+++ b/haskell/test/Lorentz/Contracts/Test/FA1_2.hs
@@ -16,9 +16,9 @@ import Lorentz.Contracts.Test.ApprovableLedger (AlSettings(..), approvableLedger
 import Michelson.Test.Integrational
 import Michelson.Typed (untypeValue)
 
-import Lorentz.Contracts.Stablecoin (Roles(..))
+import Lorentz.Contracts.Stablecoin (Roles(..), MetadataUri(..), metadataMap)
 import Lorentz.Contracts.StablecoinFA1_2
-  (Parameter, Storage(..), metadataMap, stablecoinFA1_2Contract)
+  (Parameter, Storage(..), metadataJSON, stablecoinFA1_2Contract)
 
 alOriginationFunction :: Address -> AlSettings -> IntegrationalScenarioM (TAddress Parameter)
 alOriginationFunction adminAddr (AlInitAddresses addrBalances) = do
@@ -38,7 +38,7 @@ alOriginationFunction adminAddr (AlInitAddresses addrBalances) = do
             }
         , sTransferlistContract = Nothing
         , sTotalSupply = sum $ snd <$> addrBalances
-        , sMetadata = metadataMap
+        , sMetadata = metadataMap (CurrentContract metadataJSON True)
         }
 
   TAddress @Parameter <$> originate stablecoinFA1_2Contract "" (untypeValue $ toVal storage) (toMutez 0)

--- a/haskell/test/Lorentz/Contracts/Test/TZIP16.hs
+++ b/haskell/test/Lorentz/Contracts/Test/TZIP16.hs
@@ -237,59 +237,58 @@ expectedMetadataJSON =
         "error": { "string": "CURRENT_ALLOWANCE_REQUIRED" },
         "expansion": { "string": "The given address is already a minter, you must specify its current minting allowance" },
         "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "ALLOWANCE_MISMATCH" },
+        "expansion": { "string": "The given current minting allowance does not match the minter's actual current minting allowance" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "ADDR_NOT_MINTER" },
+        "expansion": { "string": "This address is not a registered minter" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "ALLOWANCE_EXCEEDED" },
+        "expansion": { "string": "The amount of tokens to be minted exceeds your current minting allowance" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "BAD_TRANSFERLIST" },
+        "expansion": { "string": "The given address is a not a smart contract complying with the transferlist interface" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "MINTER_LIMIT_REACHED" },
+        "expansion": { "string": "Cannot add new minter because the number of minters is already at the limit" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "MISSIGNED" },
+        "expansion": { "string": "This permit's signature is invalid" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "EXPIRED_PERMIT" },
+        "expansion": { "string": "A permit was found, but it has already expired" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "NOT_PERMIT_ISSUER" },
+        "expansion": { "string": "You're not the issuer of the given permit" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "DUP_PERMIT" },
+        "expansion": { "string": "The given permit already exists" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "EXPIRY_TOO_BIG" },
+        "expansion": { "string": "The `set_expiry` entrypoint was called with an expiry value that is too big" },
+        "languages": [ "en" ]
       }
     ]
   }
   |]
 
--- TODO: Include this in the above list of errors
---{
---  "error": { "string": "ALLOWANCE_MISMATCH" },
---  "expansion": { "string": "The given current minting allowance does not match the minter's actual current minting allowance" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "ADDR_NOT_MINTER" },
---  "expansion": { "string": "This address is not a registered minter" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "ALLOWANCE_EXCEEDED" },
---  "expansion": { "string": "The amount of tokens to be minted exceeds your current minting allowance" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "BAD_TRANSFERLIST" },
---  "expansion": { "string": "The given address is a not a smart contract complying with the transferlist interface" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "MINTER_LIMIT_REACHED" },
---  "expansion": { "string": "Cannot add new minter because the number of minters is already at the limit" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "MISSIGNED" },
---  "expansion": { "string": "This permit's signature is invalid" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "EXPIRED_PERMIT" },
---  "expansion": { "string": "A permit was found, but it has already expired" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "NOT_PERMIT_ISSUER" },
---  "expansion": { "string": "You're not the issuer of the given permit" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "DUP_PERMIT" },
---  "expansion": { "string": "The given permit already exists" },
---  "languages": [ "en" ]
---},
---{
---  "error": { "string": "EXPIRY_TOO_BIG" },
---  "expansion": { "string": "The `set_expiry` entrypoint was called with an expiry value that is too big" },
---  "languages": [ "en" ]
---}

--- a/haskell/test/SMT.hs
+++ b/haskell/test/SMT.hs
@@ -508,7 +508,7 @@ stablecoinMichelsonModel
   -> ContractState
 stablecoinMichelsonModel mrAddress cc@(ContractCall {..}) cs = let
   contractEnv = dummyContractEnv { ceSender = ccSender, ceAmount = unsafeMkMutez 0 }
-  initSt = mkInitialStorage (ssToOriginationParams $ csStorage cs) mrAddress
+  initSt = mkInitialStorage (ssToOriginationParams $ csStorage cs) mrAddress Nothing
   iResult = callEntrypoint cc initSt contractEnv
   in case iResult of
     Right iRes -> let

--- a/haskell/test/Stablecoin.hs
+++ b/haskell/test/Stablecoin.hs
@@ -30,7 +30,7 @@ origination originationParams = do
   TAddress @SC.Parameter <$> tOriginate
     stablecoinContract
     "Stablecoin contract"
-    (toVal (mkInitialStorage originationParams mrAddress))
+    (toVal (mkInitialStorage originationParams mrAddress Nothing))
     (toMutez 0)
 
 spec_FA2 :: Spec

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -20,6 +20,10 @@ stablecoin.fa1.2.tz: $(sources)
 metadata.tz: $(sources)
 	$(LIGO) compile-contract --syntax pascaligo stablecoin/metadata.ligo metadata > metadata.tz
 
+# Compile contract metadata LIGO contract into its michelson representation
+tzip16-metadata.tz: $(sources)
+	$(LIGO) compile-contract --syntax pascaligo stablecoin/tzip16-metadata.ligo tzip16_metadata > tzip16-metadata.tz
+
 .PHONY: clean
 clean:
 	rm -f *.tz

--- a/ligo/stablecoin/metadata.ligo
+++ b/ligo/stablecoin/metadata.ligo
@@ -3,9 +3,6 @@
 
 #include "spec.ligo"
 
-
-type metadata_storage is token_metadata
-
 type metadata_storage is record
    token_metadata : big_map (nat, token_metadata)
 ; dummy_field : unit

--- a/ligo/stablecoin/tzip16-metadata.ligo
+++ b/ligo/stablecoin/tzip16-metadata.ligo
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: MIT
+
+type contract_metadata_storage is record
+  metadata : big_map (string, bytes)
+; dummy_field : unit // We need this field for the metadata field to be annotated with the %metadata%.
+end
+
+(*
+ * Token Metadata storage contract.
+ * We use this contract to store the metadata of the Stablecoin contract.
+ * The Stablecoin contract only needs to store the address of this contract in its storage.
+ *)
+function tzip16_metadata
+  ( const action : unit
+  ; const store  : contract_metadata_storage
+  ) : list (operation) * contract_metadata_storage is
+      ( (nil : list (operation))
+        , store
+      )


### PR DESCRIPTION
## Description

1. Add a `contract-metadata.ligo` contract to hold the contract metadata. 
2. Add options to the deploy command to specify how contract metadata should be set.

Right now two options are added. 

1.  --contract-metadata-remote

If this is given, the contract-metadata contract will be deployed, originated with the contract metadata, and the address will be stored in the metadata bigmap of the main contract, with the URI formated as specified by TZIP-16

2.  --contract-metadata-raw 

If this is provided with a string, the provided string is used as such for the metadata URI.

Apart from this, the part of metadata that have been commented out to save origination cost has been enabled.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves  #138 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
