### PR TITLE
[#131] Add `total_supply` to the storage and update code/tests to keep it in sync.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ SPDX-License-Identifier: MIT
 <!-- Prepend new entries here -->
 <!-- Don't forget to update the gas/transaction costs tables in the
 README when a new version is released. -->
+
+* [#144](https://github.com/tqtezos/stablecoin/pull/144)
+  * Add `total_supply` field to the contract.
+
 ## 1.4.0
 
 * [#134](https://github.com/tqtezos/stablecoin/pull/134)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -172,6 +172,7 @@ The next group consists of the errors that are not part of the FA2 specification
 | `NOT_PERMIT_ISSUER`          | The sender tried to set the expiry on a permit that wasn't theirs and no permit was issued to allow this call.                 |
 | `DUP_PERMIT`                 | The sender tried to issue a duplicate permit.                                                                                  |
 | `EXPIRY_TOO_BIG`             | The `set_expiry` entrypoint was called with an expiry value that is too big.                                                   |
+| `NEGATIVE_TOTAL_SUPPLY`      | The `total_supply` value was found to be less than zero after an operation. This indicates a bug in the contract.              |
 
 # Entrypoints
 

--- a/haskell/nettest/FA1_2Comparison.hs
+++ b/haskell/nettest/FA1_2Comparison.hs
@@ -82,6 +82,7 @@ fa1_2ComparisonScenario = uncapsNettest $ do
         , sOperators = mempty
         , sTokenMetadataRegistry = mrAddress
         , sMetadata = SFA2.metadataMap
+        , sTotalSupply = 0
         }
 
   comment "Originating Stablecoin FA2 contract"

--- a/haskell/src/Lorentz/Contracts/Stablecoin.hs
+++ b/haskell/src/Lorentz/Contracts/Stablecoin.hs
@@ -275,6 +275,7 @@ data Storage' big_map = Storage
   , sPermits :: big_map Address UserPermits
   , sRoles :: Roles
   , sTokenMetadataRegistry :: Address
+  , sTotalSupply :: Natural
   , sTransferlistContract :: Maybe Address
   }
 
@@ -290,7 +291,8 @@ $(customGeneric "Storage'" $ withDepths
       , fld @4 -- sPermits
       , fld @3 -- sRoles
       , fld @3 -- sTokenMetadataRegistry
-      , fld @2 -- sTransferlistContract
+      , fld @3 -- sTransferlistContract
+      , fld @3 -- sTotalSupply
       ]
     ]
   )

--- a/haskell/src/Stablecoin/Client/Contract.hs
+++ b/haskell/src/Stablecoin/Client/Contract.hs
@@ -49,4 +49,5 @@ mkInitialStorage (InitialStorageData {..}) =
     , sTokenMetadataRegistry = isdTokenMetadataRegistry
     , sTransferlistContract = isdTransferlist
     , sMetadata = metadataMap
+    , sTotalSupply = 0
     }

--- a/haskell/stack.yaml.lock
+++ b/haskell/stack.yaml.lock
@@ -50,10 +50,10 @@ packages:
     pantry-tree:
       size: 3104
       sha256: 131b69146dc474ae5e07e48f616e000cbf079a68139e03343eb582841ad83989
-    commit: d6c7c0412835acddcbf2c5914a3009330f56051e
+    commit: abc385928e69b6429595c6169b2494165aae9c77
   original:
     git: https://gitlab.com/morley-framework/morley-metadata.git
-    commit: d6c7c0412835acddcbf2c5914a3009330f56051e
+    commit: abc385928e69b6429595c6169b2494165aae9c77
 - completed:
     hackage: morley-prelude-0.3.0@sha256:9e9473ac14cfa206adf0a3700764c0251de05042f1fe45daf9cb8556079ae663,2085
     pantry-tree:

--- a/haskell/test-common/Lorentz/Contracts/Test/Common.hs
+++ b/haskell/test-common/Lorentz/Contracts/Test/Common.hs
@@ -218,6 +218,7 @@ mkInitialStorage OriginationParams{..} metadataRegistryAddress =
     , sTokenMetadataRegistry = fromMaybe metadataRegistryAddress opTokenMetadataRegistry
     , sTransferlistContract = unTAddress <$> opTransferlistContract
     , sMetadata = metadataMap
+    , sTotalSupply = sum $ Map.elems opBalances
     }
   where
     foldFn

--- a/haskell/test/Lorentz/Contracts/Test/Management.hs
+++ b/haskell/test/Lorentz/Contracts/Test/Management.hs
@@ -374,7 +374,7 @@ managementSpec originate = do
 
 
   describe "Minting" $ do
-    it "successfully mints tokens" $ integrationalTestExpectation $ do
+    it "successfully mints tokens and updates total_supply" $ integrationalTestExpectation $ do
       let
         originationParams =
             addMinter (wallet1, 30)
@@ -406,6 +406,10 @@ managementSpec originate = do
         lCallEP stablecoinContract (Call @"Balance_of") balanceRequest
 
         lExpectViewConsumerStorage consumer [balanceExpected]
+
+        lExpectStorage @Storage stablecoinContract $ \(sTotalSupply -> ts) ->
+          unless (ts == 30) $ -- Started with 0 tokens and minted 30 tokens so total supply should be 30
+            Left $ CustomTestError "Total supply was not updated as expected"
 
     it "aborts whole transaction if the sum of minting tokens at a given step exceeds current minting allowance" $ integrationalTestExpectation $ do
       let
@@ -443,7 +447,7 @@ managementSpec originate = do
 
 
   describe "Burning" $ do
-    it "burns tokens as expected" $ integrationalTestExpectation $ do
+    it "burns tokens and updates total_supply as expected" $ integrationalTestExpectation $ do
       let
         originationParams =
             addMinter (wallet1, 0)
@@ -471,6 +475,10 @@ managementSpec originate = do
         lCallEP stablecoinContract (Call @"Balance_of") balanceRequest
 
         lExpectViewConsumerStorage consumer [balanceExpected]
+
+        lExpectStorage @Storage stablecoinContract $ \(sTotalSupply -> ts) ->
+          unless (ts == 5) $ -- Started with 35 tokens and burned 30 tokens so total supply should be 5
+            Left $ CustomTestError "Total supply was not updated as expected"
 
     it "removes account if balance after burning is zero" $ integrationalTestExpectation $ do
 

--- a/ligo/stablecoin/spec.ligo
+++ b/ligo/stablecoin/spec.ligo
@@ -288,6 +288,7 @@ type storage is record
 ; permits                 : permits
 ; default_expiry          : seconds
 ; metadata                : metadata
+; total_supply            : nat
 end
 
 type entrypoint is list (operation) * storage


### PR DESCRIPTION
## Description

We have to add `total_supply` field to the contract storage as
required by recent changes to TZIP-12. So we add it in this PR
and update spec, tests, and storage initialization functions.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #144

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
