### PR TITLE
Remove unused LIGO types from FA1.2 contract

### DIFF
--- a/ligo/stablecoin/fa1.2/spec.ligo
+++ b/ligo/stablecoin/fa1.2/spec.ligo
@@ -106,8 +106,6 @@ type transferlist_transfer_item is michelson_pair(address, "from", list(address)
 
 type transferlist_assert_transfers_param is list(transferlist_transfer_item)
 
-type transferlist_assert_receiver_param is address
-
 type transferlist_assert_receivers_param is list(address)
 
 type set_transferlist_param is option(address)
@@ -131,9 +129,6 @@ type user_permits is
 type permits is big_map (address, user_permits)
 
 type permit_param is (key * (signature * blake2b_hash))
-
-type revoke_param is blake2b_hash * address
-type revoke_params is list(revoke_param)
 
 type set_expiry_param is (seconds * option(blake2b_hash * address))
 


### PR DESCRIPTION

## Description

There are a couple of types in the FA1.2 version of the contract that are unused and don't impact on the compiled result.
They don't create a problem, but this removes it just to clean up the LIGO source code.


## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
