### PR TITLE
[#131] Adds some more missing TZIP-16 metadata and amend readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ To measure and collect these numbers:
     tezos-client get balance for nettest
     ```
 1. Run `cd haskell && stack test stablecoin:test:stablecoin-nettest`
+
+   This deploys the FA2 and FA1.2 contracts along with the corresponding
+   metadata contracts. So metadata is deployed to separate contracts and linked
+   from the main contracts via the TZIP-016 metadata URI. After this some tests
+   on the deployed contracts. (The origination costs in the table above does
+   not include origination costs of these metadata contracts).
+
 1. The logs should show these two messages, with two addresses:
     ```
     Originated smart contract Stablecoin FA1.2 with address <...>

--- a/haskell/src/Lorentz/Contracts/Stablecoin.hs
+++ b/haskell/src/Lorentz/Contracts/Stablecoin.hs
@@ -508,6 +508,9 @@ data MetadataUri metadata
 metadataJSON :: Maybe FA2.TokenMetadata -> Metadata (ToT Storage)
 metadataJSON mtmd  =
   TZ.name  "stablecoin" <>
+  TZ.description  "Tezos Stablecoin project implements an FA2-compatible token smart contract.\
+    \ It draws inspiration from popular permissioned asset contracts like CENTRE Fiat Token and other similar contracts.\
+    \ The contract is implemented in the LIGO language." <>
   TZ.version (toText $ showVersion version) <>
   TZ.license (License { lName = "MIT", lDetails = Nothing }) <>
   TZ.authors
@@ -544,6 +547,7 @@ metadataJSON mtmd  =
             , mkError [mt|NOT_PERMIT_ISSUER|]          [mt|You're not the issuer of the given permit|]
             , mkError [mt|DUP_PERMIT|]                 [mt|The given permit already exists|]
             , mkError [mt|EXPIRY_TOO_BIG|]             [mt|The `set_expiry` entrypoint was called with an expiry value that is too big|]
+            , mkError [mt|NEGATIVE_TOTAL_SUPPLY|]      [mt|The total_supply value was found to be less than zero after an operation. This indicates a bug in the contract.|]
             ] <>
   TZ.views (case mtmd of
      Nothing ->

--- a/haskell/test/Lorentz/Contracts/Test/TZIP16.hs
+++ b/haskell/test/Lorentz/Contracts/Test/TZIP16.hs
@@ -76,12 +76,13 @@ expectedMetadataJSON =
   [i|
   {
     "name": "stablecoin",
-    "homepage": "https://github.com/tqtezos/stablecoin/",
+    "description": "Tezos Stablecoin project implements an FA2-compatible token smart contract. It draws inspiration from popular permissioned asset contracts like CENTRE Fiat Token and other similar contracts. The contract is implemented in the LIGO language.",
     "version": "#{showVersion version}",
     "interfaces": [
       "TZIP-012",
       "TZIP-017"
     ],
+    "homepage": "https://github.com/tqtezos/stablecoin/",
     "authors": [
       "Serokell <https://serokell.io/>",
       "TQ Tezos <https://tqtezos.com/>"
@@ -292,6 +293,11 @@ expectedMetadataJSON =
       {
         "error": { "string": "EXPIRY_TOO_BIG" },
         "expansion": { "string": "The `set_expiry` entrypoint was called with an expiry value that is too big" },
+        "languages": [ "en" ]
+      },
+      {
+        "error": { "string": "NEGATIVE_TOTAL_SUPPLY" },
+        "expansion": { "string": "The total_supply value was found to be less than zero after an operation. This indicates a bug in the contract." },
         "languages": [ "en" ]
       }
     ]


### PR DESCRIPTION
## Description

Since we have added more options w.r.t deploying the contracts
and metadata, we should make it more clear how it is being done in
nettests. So the section is amended.

The TIZP-016 spec describe some top level fields, and we
include most of them in our Metadata, except for the 'description'
field. The 'NEGATIVE_TOTAL_SUPPLY' error is also missing from the list
of errors. So this PR adds them both.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
