### PR TITLE
[#156] Update morley building in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -80,30 +80,23 @@ let
     local-packages = local-packages;
   };
 
-  # This ugly workaround should be removed, once the https://github.com/typeclasses/hex-text/pull/5
-  # is merged
-  morley = pkgs.haskell.lib.doJailbreak (pkgs.haskellPackages.callHackageDirect {
+    # morley in nixpkgs is very old
+  morley = pkgs.haskellPackages.callHackageDirect {
     pkg = "morley";
-    ver = "1.7.1";
-    sha256 = "1ps2191za6agm78hqsrra185in4sjdaihqkn4hxng33csq2bj1vh";
+    ver = "1.11.1";
+    sha256 = "0c9fg4f5dmji5wypa8qsq0bhj1p55l1f6nxdn0sdc721p5rchx28";
   } {
+    uncaught-exception = pkgs.haskellPackages.callHackageDirect {
+      pkg = "uncaught-exception";
+      ver = "0.1.0";
+      sha256 = "0fqrhyf2jn3ayp3aiirw6mms37w3nwk4h3i7l4hqw481ps0ml16d";
+    } {};
     cryptonite = pkgs.haskell.lib.doJailbreak (pkgs.haskellPackages.callHackageDirect {
       pkg = "cryptonite";
       ver = "0.27";
       sha256 = "0y8mazalbkbvw60757av1s6q5b8rpyks4lzf5c6dhp92bb0rj5y7";
     } {});
-    hex-text = pkgs.haskell.lib.doJailbreak (pkgs.haskellPackages.callHackageDirect {
-      pkg = "hex-text";
-      ver = "0.1.0.0";
-      sha256 = "13y3yws4xv99ngd8rgn8n02cyzb3kvyyh6zd88ficmqs4cnhvw7y";
-    } {
-      base16-bytestring = pkgs.haskell.lib.doJailbreak (pkgs.haskellPackages.callHackageDirect {
-        pkg = "base16-bytestring";
-        ver = "0.1.1.7";
-        sha256 = "0sv4gvaz1hwllv7dpm8b8xkrpsi1bllgra2niiwpszpq14bzpail";
-      } {});
-     });
-  });
+  };
 in
 {
   lib = project.stablecoin.components.library;


### PR DESCRIPTION
## Description
Problem: There is a workaround to make morley binary work when building
it via nix. This workaround was added to overcome the issue in hex-text
package. However, this issue was resolved.

Solution: Update morley building in default.nix and remove workaround.

Also, update the used morley version to the latest version from hackage.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #156

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
