### PR TITLE
Don't use dedicated runner for scheduled jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 TQ Tezos
+# SPDX-FileCopyrightText: 2021 TQ Tezos
 # SPDX-License-Identifier: MIT
 
 env:
@@ -46,6 +46,7 @@ steps:
  - wait
 
  - label: build library
+   key: build_library
    if: *not_scheduled
    commands:
      - eval "$FETCH_CONTRACT"
@@ -53,12 +54,15 @@ steps:
 
  - label: haddock
    if: *not_scheduled
+   depends_on: build_library
    commands:
      - eval "$FETCH_CONTRACT"
      - nix build -L -f. haddock
 
  - label: test
+   key: test
    if: *not_scheduled
+   depends_on: build_library
    commands:
      - eval "$FETCH_CONTRACT"
      - cd haskell
@@ -66,7 +70,9 @@ steps:
      - ./result/bin/stablecoin-test
 
  - label: nettest-local-chain-008
+   key: nettest-local-chain-008
    if: *not_scheduled
+   depends_on: build_library
    env:
      NETTEST_NODE_ENDPOINT: "http://localhost:8733"
      # this key is defined in local-chain bootstrap accounts list in
@@ -82,7 +88,9 @@ steps:
         limit: 1
 
  - label: nettest-scheduled-edonet
+   key: nettest-scheduled-edonet
    if: build.source == "schedule"
+   depends_on: build_library
    env:
      NETTEST_NODE_ENDPOINT: "http://edo.testnet.tezos.serokell.team:8732"
      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
@@ -93,7 +101,9 @@ steps:
    timeout_in_minutes: 180
 
  - label: weeder
+   key: weeder
    if: *not_scheduled
+   depends_on: build_library
    commands:
      - eval "$FETCH_CONTRACT"
      - cd haskell
@@ -104,6 +114,11 @@ steps:
 
  - label: packaging
    if: *not_scheduled
+   depends_on:
+     - test
+     - nettest-local-chain-008
+     - nettest-scheduled-edonet
+     - weeder
    commands:
      - eval "$FETCH_CONTRACT"
      - nix-build -A stablecoin-client -o stablecoin-static

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,9 +83,6 @@ steps:
 
  - label: nettest-scheduled-edonet
    if: build.source == "schedule"
-   # use another agent for long scheduled jobs
-   agents:
-    queue: "scheduled"
    env:
      NETTEST_NODE_ENDPOINT: "http://edo.testnet.tezos.serokell.team:8732"
      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some


### PR DESCRIPTION
## Description
Problem: We now have more CI agents and having a dedicated scheduled
agent is no longer needed.

Solution: Remove scheduled queue tag.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/OPS-1193
## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
