### PR TITLE
[#136] Remove coercions between 'Alias' and 'AliasHint'

### DIFF
--- a/haskell/src/Stablecoin/Client/Cleveland/Caps.hs
+++ b/haskell/src/Stablecoin/Client/Cleveland/Caps.hs
@@ -63,6 +63,7 @@ runStablecoinClient (NettestEnv env envKey) scenario = displayUncaughtException 
   disableAlphanetWarning
   storageAddress <- runMorleyClientM env $
     resolveAddressMaybe (AddressAlias nettestAddressAlias)
+  -- TODO morley/#667 replace this with `setupMoneybagAddress`
   nettestAddr <- case (envKey, storageAddress) of
     (Nothing, Just addr) -> pure addr
     (Nothing, Nothing) -> throwM NoNettestAddress


### PR DESCRIPTION
Problem: We use `coerce` to convert `AliasHint` to alias in
`stablecoin-client`. This coersion is safe only when no alias
prefix was set via CLI option.

Solution: Added prefix accounting when converting from `AliasHint`
to `Alias`, hence the conversion became safe even if the prefix
option was set.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #136

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
