### PR TITLE
[Chore] Remove tests from CI for protocol 010

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,12 +70,12 @@ steps:
      - nix build -L -f .. test
      - ./result/bin/stablecoin-test --nettest-mode=disable-network
 
- - label: nettest-local-chain-010
-   key: nettest-local-chain-010
+ - label: nettest-local-chain-011
+   key: nettest-local-chain-011
    if: *not_scheduled
    depends_on: build_library
    env:
-     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
+     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
      # this key is defined in local-chain bootstrap accounts list in
      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
      TASTY_NETTEST_MONEYBAG_SECRET_KEY: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
@@ -89,33 +89,6 @@ steps:
    retry: &retry-nettest
       automatic:
         limit: 1
-
- - label: nettest-local-chain-011
-   key: nettest-local-chain-011
-   if: *not_scheduled
-   depends_on: build_library
-   env:
-     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
-     # this key is defined in local-chain bootstrap accounts list in
-     # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
-     TASTY_NETTEST_MONEYBAG_SECRET_KEY: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
-   commands: *run-nettest
-   retry: *retry-nettest
-
- - label: nettest-scheduled-granadanet
-   key: nettest-scheduled-granadanet
-   if: build.source == "schedule"
-   depends_on:
-     - build_library
-     - LIGO-contract
-   env:
-     TASTY_NETTEST_NODE_ENDPOINT: "https://granada.testnet.tezos.serokell.team"
-     # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
-     # more tz, its address: tz1ij8gUYbMRUXa4xX3mNvKguhaWG9GGbURn
-     TASTY_NETTEST_MONEYBAG_SECRET_KEY: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
-   commands: *run-nettest
-   retry: *retry-nettest
-   timeout_in_minutes: 360
 
  - label: nettest-scheduled-hangzhounet
    key: nettest-scheduled-hangzhounet


### PR DESCRIPTION
## Description

The granada/010 protocol is no longer active on mainnet and its testnet is no longer relevant to us.

This removes the tests on CI based on said protocol

## Related issue(s)

[TM-603](https://issues.serokell.io/issue/TM-603)

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
