### PR TITLE
[Chore] Replace hangzhou steps with ithaca in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,12 +70,12 @@ steps:
      - nix build -L -f .. test
      - ./result/bin/stablecoin-test --cleveland-mode=disable-network
 
- - label: nettest-local-chain-011
-   key: nettest-local-chain-011
+ - label: nettest-local-chain-012
+   key: nettest-local-chain-012
    if: *not_scheduled
    depends_on: build_library
    env:
-     TASTY_CLEVELAND_NODE_ENDPOINT: "http://localhost:8734"
+     TASTY_CLEVELAND_NODE_ENDPOINT: "http://localhost:8733"
      # this key is defined in local-chain bootstrap accounts list in
      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
      TASTY_CLEVELAND_MONEYBAG_SECRET_KEY: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
@@ -88,14 +88,14 @@ steps:
       automatic:
         limit: 1
 
- - label: nettest-scheduled-hangzhounet
-   key: nettest-scheduled-hangzhounet
+ - label: nettest-scheduled-ithacanet
+   key: nettest-scheduled-ithacanet
    if: build.source == "schedule"
    depends_on:
      - build_library
      - LIGO-contract
    env:
-     TASTY_CLEVELAND_NODE_ENDPOINT: "https://hangzhou.testnet.tezos.serokell.team"
+     TASTY_CLEVELAND_NODE_ENDPOINT: "https://ithaca.testnet.tezos.serokell.team"
      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
      # more tz, its address: tz1ij8gUYbMRUXa4xX3mNvKguhaWG9GGbURn
      TASTY_CLEVELAND_MONEYBAG_SECRET_KEY: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
@@ -121,8 +121,8 @@ steps:
    if: *not_scheduled
    depends_on:
      - test
-     - nettest-local-chain-011
-     - nettest-scheduled-hangzhounet
+     - nettest-local-chain-012
+     - nettest-scheduled-ithacanet
      - weeder
    commands:
      - eval "$FETCH_CONTRACT"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,12 +78,19 @@ steps:
      TASTY_CLEVELAND_NODE_ENDPOINT: "http://localhost:8733"
      # this key is defined in local-chain bootstrap accounts list in
      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
-     TASTY_CLEVELAND_MONEYBAG_SECRET_KEY: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
+     CHAIN_TEST_MONEYBAG_SECRET_KEY: "unencrypted:edsk3GjD83F7oj2LrnRGYQer99Fj69U2QLyjWGiJ4UoBZNQwS38J4v"
    commands: &run-nettest
      - eval "$FETCH_CONTRACT"
      - cd haskell/
+     - export PATH=$(nix-build ../ -A stablecoin-client)/bin:$PATH
      - nix build -L -f .. test
-     - nix run -f ../ tezos-client stablecoin-client -c ./result/bin/stablecoin-test --cleveland-mode=only-network -d "$(mktemp -d --tmpdir="$PWD")"
+     # Note that 'refill-balance' below is the initial 'TASTY_CLEVELAND_MONEYBAG_SECRET_KEY' balance
+     # which may need to be adjusted in case of insufficient balance errors
+     - $(nix-build ../ -A run-chain-tests
+         --argstr refill-balance 50
+         --argstr node-endpoint $$TASTY_CLEVELAND_NODE_ENDPOINT
+         --argstr step-moneybag $$CHAIN_TEST_MONEYBAG_SECRET_KEY --no-out-link
+         --argstr scenario './result/bin/stablecoin-test --cleveland-mode=only-network')
    retry: &retry-nettest
       automatic:
         limit: 1
@@ -98,7 +105,7 @@ steps:
      TASTY_CLEVELAND_NODE_ENDPOINT: "https://ithaca.testnet.tezos.serokell.team"
      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
      # more tz, its address: tz1ij8gUYbMRUXa4xX3mNvKguhaWG9GGbURn
-     TASTY_CLEVELAND_MONEYBAG_SECRET_KEY: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
+     CHAIN_TEST_MONEYBAG_SECRET_KEY: "unencrypted:edsk4EYgVvKVKppJXAyeoqxJrNeyoktNqmcx5op1CFht9P1p8pPxp7"
      # Running all of the tests on network will end up draining the moneybag; for now, only FA1.2 tests are run
      TASTY_PATTERN: '/Test.FA1_2/||/Lorentz.Contracts.Nettest/'
    commands: *run-nettest

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@
 , morley-infra ? (import sources.morley-infra)
 }:
 let
-  inherit (morley-infra) tezos-client weeder-hacks;
+  inherit (morley-infra) tezos-client weeder-hacks run-chain-tests;
   haskell-nix =
     if static
     then pkgs.pkgsCross.musl64.haskell-nix
@@ -92,5 +92,5 @@ in
   test = project.stablecoin.components.tests.stablecoin-test;
   nettest = project.stablecoin.components.tests.stablecoin-nettest;
   stablecoin-client = project.stablecoin.components.exes.stablecoin-client;
-  inherit tezos-contract tezos-contract-fa1-2 tezos-metadata-contract tezos-client pkgs weeder-script morley;
+  inherit tezos-contract tezos-contract-fa1-2 tezos-metadata-contract tezos-client pkgs weeder-script morley run-chain-tests;
 }

--- a/default.nix
+++ b/default.nix
@@ -7,11 +7,12 @@
     sourcesOverride = { hackage = sources."hackage.nix"; stackage = sources."stackage.nix"; };
   }
 , pkgs ? import sources.nixpkgs haskell-nix.nixpkgsArgs
-, weeder-hacks ? import sources.haskell-nix-weeder { inherit pkgs; }
 , ligo ? (pkgs.runCommand "ligo" {} "mkdir -p $out/bin; cp ${sources.ligo} $out/bin/ligo; chmod +x $out/bin/ligo")
 , morley ? (import "${sources.morley}/ci.nix").packages.morley.exes.morley
+, morley-infra ? (import sources.morley-infra)
 }:
 let
+  inherit (morley-infra) tezos-client weeder-hacks;
   haskell-nix =
     if static
     then pkgs.pkgsCross.musl64.haskell-nix
@@ -78,19 +79,10 @@ let
     buildPhase = "make metadata.tz";
     installPhase = "cp metadata.tz $out";
   };
-  tezos-client = (import "${sources.tezos-packaging}/nix/build/pkgs.nix" {}).ocamlPackages.tezos-client;
 
-  # nixpkgs has weeder 2, but we use weeder 1
-  weeder-legacy = pkgs.haskellPackages.callHackageDirect {
-    pkg = "weeder";
-    ver = "1.0.9";
-    sha256 = "0gfvhw7n8g2274k74g8gnv1y19alr1yig618capiyaix6i9wnmpa";
-  } {};
-
-  weeder-script = weeder-hacks.weeder-script {
-    weeder = weeder-legacy;
+  weeder-script = morley-infra.weeder-script {
     hs-pkgs = project;
-    local-packages = local-packages;
+    inherit local-packages;
   };
 
 in

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -13,7 +13,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley-metadata.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    81b947ca1d74f3487a5b5c8e2141c37bf374f747 # master
+    c7d545897bad10bc98ceb1d9672f184b108dd40e # master
   subdirs:
     - code/morley-metadata
     - code/morley-metadata-test
@@ -22,7 +22,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley-ledgers.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    b39a971f42bb113a5b3e23c9145253e27ad6e049 # master
+    81ce02e733b6c33e4d4fe8034e65d95f03a5f0a7 # master
   subdirs:
     - code/morley-ledgers
     - code/morley-ledgers-test
@@ -30,21 +30,16 @@ extra-deps:
 - git:
     https://gitlab.com/morley-framework/indigo.git
   commit:
-    e879e5f282afb8d25d72d8ba132f22d3d9e628a1 # master
+    8074d3c6a03d6e79b7ddb48b323bca72bf6c2767 # master
   subdirs:
     - .
 
-- git:
-    https://gitlab.com/morley-framework/morley.git
-    # ^ CI cannot use ssh, so we use http clone here
-  commit:
-    146da727ff486c46b0ec9f392d955f07d797848e # master
-  subdirs:
-    - code/morley
-    - code/morley-client
-    - code/cleveland
-    - code/lorentz
-    - code/morley-prelude
+# Stable versions available on Hackage
+- cleveland-0.1.1
+- morley-1.16.3
+- morley-client-0.1.1
+- morley-prelude-0.5.1
+- lorentz-0.13.3
 
 # Required by morley
 - git: https://github.com/serokell/base-noprelude.git

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -79,10 +79,10 @@
         "homepage": "",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "2fd958106fc9cd318b68c3a8eef5091bcb0877ba",
-        "sha256": "0j5jb5vyvfjzwcb0giz8as3aafd2gn1n78is92s3yjz05zqdgjsg",
+        "rev": "012636a917cddcad59d06ed80ec3b7d5d7a893e2",
+        "sha256": "1m9nnjrxb5iar926qdqsi9f2nb5r4rya8a23rmj8871815jwalcn",
         "type": "tarball",
-        "url": "https://github.com/serokell/tezos-packaging/archive/2fd958106fc9cd318b68c3a8eef5091bcb0877ba.tar.gz",
+        "url": "https://github.com/serokell/tezos-packaging/archive/012636a917cddcad59d06ed80ec3b7d5d7a893e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xrefcheck": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "943f98f0927f499d32c535921c4df25f6a4359c9",
-        "sha256": "1k00gmm98fk5wm1xd1612b7bfzn0x1nfsc1csygr2mfnldji9yd2",
+        "rev": "92a2b1faff6afb43b217bf8b34e48147d5505e77",
+        "sha256": "0nyhz0a1rwfyavhhknh1822rm2vc2a97r7k94dsf0nhsh1ing3pc",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/943f98f0927f499d32c535921c4df25f6a4359c9.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/92a2b1faff6afb43b217bf8b34e48147d5505e77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix-weeder": {
@@ -67,10 +67,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "3f43e2e72e0853e911497277ec094933892718a9",
-        "sha256": "1z8ca4ih8lyzadlgr8ppki78qgw0f636zy1fwd61m7gafc5jcycf",
+        "rev": "8222c5eef15f0882412a4afc5bfc9d3a70edef1d",
+        "sha256": "0169qvd3xb3a3bcr2wj5yqrhb9v5i5198jp1zawlgimq4px8li1y",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/stackage.nix/archive/3f43e2e72e0853e911497277ec094933892718a9.tar.gz",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/8222c5eef15f0882412a4afc5bfc9d3a70edef1d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/input-output-hk/hackage.nix/archive/92a2b1faff6afb43b217bf8b34e48147d5505e77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "haskell-nix-weeder": {
-        "branch": "master",
-        "description": "haskell.nix + weeder",
-        "homepage": null,
-        "owner": "serokell",
-        "repo": "haskell-nix-weeder",
-        "rev": "a959fce7499df473e13336959cba77fbc87f3b7f",
-        "sha256": "1pmlndvbhzxj1k5f87d9dxfa00zbvmkmvnbd1davzwg77bd639l0",
-        "type": "tarball",
-        "url": "https://github.com/serokell/haskell-nix-weeder/archive/a959fce7499df473e13336959cba77fbc87f3b7f.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
@@ -49,6 +37,13 @@
         "url": "https://gitlab.com/morley-framework/morley/-/archive/morley-1.16.2/morley-morley-1.16.2.tar.gz",
         "url_template": "https://gitlab.com/morley-framework/morley/-/archive/morley-<rev>/morley-morley-<rev>.tar.gz"
     },
+    "morley-infra": {
+        "rev": "7f3609264ee708576b1d2f22fee789f713ab7975",
+        "sha256": "031rc2bh3a7gnvhiv602g6xa532m56cfwmrwbxnrl0bc3g7d9rrk",
+        "type": "tarball",
+        "url": "https://gitlab.com/morley-framework/morley-infra/-/archive/7f3609264ee708576b1d2f22fee789f713ab7975/morley-infra-7f3609264ee708576b1d2f22fee789f713ab7975.tar.gz",
+        "url_template": "https://gitlab.com/morley-framework/morley-infra/-/archive/<rev>/morley-infra-<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "master",
         "description": "Pinned Nixpkgs tree (master follows nixos-unstable-small, only tags have stable history)",
@@ -71,18 +66,6 @@
         "sha256": "0169qvd3xb3a3bcr2wj5yqrhb9v5i5198jp1zawlgimq4px8li1y",
         "type": "tarball",
         "url": "https://github.com/input-output-hk/stackage.nix/archive/8222c5eef15f0882412a4afc5bfc9d3a70edef1d.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "tezos-packaging": {
-        "branch": "master",
-        "description": "Various form of distribution for tezos-related executables",
-        "homepage": "",
-        "owner": "serokell",
-        "repo": "tezos-packaging",
-        "rev": "012636a917cddcad59d06ed80ec3b7d5d7a893e2",
-        "sha256": "1m9nnjrxb5iar926qdqsi9f2nb5r4rya8a23rmj8871815jwalcn",
-        "type": "tarball",
-        "url": "https://github.com/serokell/tezos-packaging/archive/012636a917cddcad59d06ed80ec3b7d5d7a893e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xrefcheck": {


### PR DESCRIPTION
## Description
Problem: Tezos has a new protocol and we should check if this project is
compatible with it.

Solution: Replace hangzhou local-chain and scheduled testnet jobs with ithaca
in the CI configuration.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->
https://issues.serokell.io/issue/TM-628

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
