### PR TITLE
[Chore] Set last Ligo version tested on a release

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
   }
 , pkgs ? import sources.nixpkgs haskell-nix.nixpkgsArgs
 , weeder-hacks ? import sources.haskell-nix-weeder { inherit pkgs; }
-, ligo ? (import "${sources.ligo}/nix" { }).ligo-bin
+, ligo ? (pkgs.runCommand "ligo" {} "mkdir -p $out/bin; cp ${sources.ligo} $out/bin/ligo; chmod +x $out/bin/ligo")
 , morley ? (import "${sources.morley}/ci.nix").packages.morley.exes.morley
 }:
 let

--- a/ligo/README.md
+++ b/ligo/README.md
@@ -16,7 +16,9 @@ You also need [`tezos-client`](http://tezos.gitlab.io/introduction/howtoget.html
 
 In order to build the LIGO smart contracts you need to have [`ligo`](https://ligolang.org/) in your `$PATH`.
 You can provide a different name/command to launch `ligo` using the `$LIGO` environment variable.
+
 Since LIGO is an actively developed project, some versions of it may be incompatible with Stablecoin.
-The revision specified in the [sources.json](/nix/sources.json) file is guaranteed to be compatible.
+The latest working version tested is [0.10.0](https://gitlab.com/ligolang/ligo/-/releases/0.10.0).
+
 Use [`Makefile`](/ligo/Makefile) to compile the smart contracts.
 For example, running `make` without arguments in this folder should produce `stablecoin.tz`.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,10 +36,11 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ligo": {
-        "ref": "dev",
-        "repo": "https://gitlab.com/ligolang/ligo",
-        "rev": "b6c3a9d4257bda78af46250a447ce78c5d2291a4",
-        "type": "git"
+        "rev": "0.10.0",
+        "sha256": "534d5f4f6b5371c829ac96ced351b2ad45d7fb0afb33153a72d870d7a3c940c7",
+        "type": "file",
+        "url": "https://gitlab.com/ligolang/ligo/-/jobs/1036880076/artifacts/raw/ligo",
+        "url_template": "https://gitlab.com/ligolang/ligo/-/jobs/1036880076/artifacts/raw/ligo"
     },
     "morley": {
         "rev": "1.15.1",


### PR DESCRIPTION
## Description

Problem: the ligo README currently points at a rolling release version,
which is not very convenient to get in case a new version breaks
compatibility. Moreover, there are now issues with fetching such an old
ligo release from source.

Solution: set the last tested working ligo version to 0.10 and
update the nix sources to get ligo as a static binary.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [x] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
