### PR TITLE
[Chore] Fix ligo binary hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -56,6 +56,13 @@ let
         # disable haddock for dependencies
         doHaddock = false;
       }
+      {
+        packages.stablecoin.components.library = {
+          preBuild = ''
+            cp -rT ${projectSrc}/test/resources test/resources/
+          '';
+        };
+      }
     ];
   };
   tezos-contract = pkgs.stdenv.mkDerivation {
@@ -88,7 +95,11 @@ let
 in
 {
   lib = project.stablecoin.components.library;
-  haddock = project.stablecoin.components.library.haddock;
+  haddock = project.stablecoin.components.library.haddock.overrideAttrs(o: {
+    buildPhase = ''
+      cp -rT ${projectSrc}/test/resources test/resources/
+    '' + o.buildPhase;
+  });
   test = project.stablecoin.components.tests.stablecoin-test;
   nettest = project.stablecoin.components.tests.stablecoin-nettest;
   stablecoin-client = project.stablecoin.components.exes.stablecoin-client;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -25,7 +25,7 @@
     },
     "ligo": {
         "rev": "0.46.1",
-        "sha256": "165xh33c88inh3wimrm82hw8szl1say2xl9cm0dkvxkkd93p0gqq",
+        "sha256": "167lq0kjxq1m48sp7cpwka9c3jgypryww5xwkp3j065rrw4y9di3",
         "type": "file",
         "url": "https://gitlab.com/ligolang/ligo/-/jobs/2702841321/artifacts/raw/ligo",
         "url_template": "https://gitlab.com/ligolang/ligo/-/jobs/2702841321/artifacts/raw/ligo"


### PR DESCRIPTION
## Description
Problem: For some reason, after nix update, CI started to complain that ligo binary has an unexcepted hash.

Solution: Fix hash.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items
Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.
If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).
If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock
  - [ ] I updated [changelog](../tree/master/ChangeLog.md) unless I am sure my changes are
        not essential.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
